### PR TITLE
Collect raw SMART values

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -292,7 +292,7 @@ def collect_ata_metrics(device):
                 **device.base_labels,
             }
 
-            for col in 'value', 'worst', 'threshold':
+            for col in 'value', 'worst', 'threshold', 'raw_value':
                 yield Metric(
                     'attr_{col}'.format(name=entry["name"], col=col),
                     labels, entry[col])


### PR DESCRIPTION
At least on Hitachi hard disks the value of the Temperature_Celsius
attribute is not useful to the system administrator. It is the raw
value that actually contains the temperature in celsius.

Signed-off-by: Timo Juhani Lindfors <timo.lindfors@iki.fi>