### PR TITLE
Fix apt.sh arch duplication (#7)

### DIFF
--- a/apt.sh
+++ b/apt.sh
@@ -12,7 +12,7 @@ upgrades="$(/usr/bin/apt-get --just-print upgrade \
   | /usr/bin/uniq -c \
   | awk '{ gsub(/\\\\/, "\\\\", $2); gsub(/\"/, "\\\"", $2);
            gsub(/\[/, "", $3); gsub(/\]/, "", $3);
-           print "apt_upgrades_pending{origin=\"" $2 "\",arch=\"" $3 "\"} " $1}'
+           print "apt_upgrades_pending{origin=\"" $2 "\",arch=\"" $NF "\"} " $1}'
 )"
 
 echo '# HELP apt_upgrades_pending Apt package pending updates by origin.'


### PR DESCRIPTION
In some cases apt.sh could output duplicated arch values causing the
following error:

Aug 29 12:12:22 host123 prometheus-node-exporter[2235]: time="2019-08-29T12:12:22Z" level=error msg="error gathering metrics: [from Gatherer #2] collected metric \"apt_upgrades_pending\" { label:<name:\"arch\" value:\"Debian/Ubuntu\" > label:<name:\"origin\" value:\"PostgreSQLfor\" > gauge:<value:6 > } was collected before with the same name and label values\n" source="log.go:172"

Signed-off-by: Andrey Arapov <andrey.arapov@nixaid.com>