### PR TITLE
smartmon.sh: don't fail on nvme, don't print error to metrics.

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -186,8 +186,9 @@ for device in ${device_list}; do
   sat+megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
   scsi) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  nvme*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   *)
-    echo "disk type is not sat, scsi or megaraid but ${type}"
+      (>&2 echo "disk type is not sat, scsi, nvme or megaraid but ${type}")
     exit
     ;;
   esac


### PR DESCRIPTION
smartctl can deal with NVMes (at least in newer versions) and return
some data. When encountering an unknown disk type, don't print to
stdout, as this will break the node exporter. Print the error message to
stderr.

I re-submitted this per https://github.com/prometheus/node_exporter/pull/1313, as I'm still affected by the bug.