### PR TITLE
Update storcli.py to work with older cards without ROC temp sensor or…

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -100,9 +100,10 @@ def handle_sas_controller(response):
 def handle_megaraid_controller(response):
     (controller_index, baselabel) = get_basic_controller_info(response)
 
-    # BBU Status Optimal value is 0 for cachevault and 32 for BBU
-    add_metric('battery_backup_healthy', baselabel,
-               int(response['Status']['BBU Status'] in [0, 32]))
+    if response['Status']['BBU Status'] != 'NA':
+        # BBU Status Optimal value is 0 for normal, 8 for charging
+        add_metric('battery_backup_healthy', baselabel,
+                   int(response['Status']['BBU Status'] in [0, 8]))
     add_metric('degraded', baselabel, int(response['Status']['Controller Status'] == 'Degraded'))
     add_metric('failed', baselabel, int(response['Status']['Controller Status'] == 'Failed'))
     add_metric('healthy', baselabel, int(response['Status']['Controller Status'] == 'Optimal'))

--- a/storcli.py
+++ b/storcli.py
@@ -110,10 +110,17 @@ def handle_megaraid_controller(response):
     add_metric('scheduled_patrol_read', baselabel,
                int('hrs' in response['Scheduled Tasks']['Patrol Read Reoccurrence']))
     for cvidx, cvinfo in enumerate(response.get('Cachevault_Info', [])):
-        add_metric('cv_temperature',
-                   baselabel + ',cvidx="' + str(cvidx) + '"',
-                   int(cvinfo['Temp'].replace('C', ''))
-                   )
+        if 'Temp' in cvinfo:
+            add_metric('cv_temperature',
+                       baselabel + ',cvidx="' + str(cvidx) + '"',
+                       int(cvinfo['Temp'].replace('C', ''))
+                       )
+    for bbuidx, bbuinfo in enumerate(response.get('BBU_Info', [])):
+        if 'Temp' in bbuinfo:
+            add_metric('bbu_temperature',
+                       baselabel + ',bbuidx="' + str(bbuidx) + '"',
+                       int(bbuinfo['Temp'].replace('C', ''))
+                       )
 
     time_difference_seconds = -1
     system_time = datetime.strptime(response['Basics'].get('Current System Date/time'),


### PR DESCRIPTION
… Cachevault_info

Also:
* updates URL to storcli documentation and bumps version number
* adds "megaraid_bbu_temperature", analagous to "megaraid_cv_temperature" but for devices with BBU rather than Cachevault
* suppresses "megaraid_battery_backup_healthy" metric for devices where BBU is not present

Fixes #19, #27

Signed-off-by: Brian Candler <b.candler@pobox.com>