### PR TITLE
Include drive serial number as label in megaraid_pd_info

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -189,6 +189,8 @@ def create_metrics_of_physical_drive(physical_drive, detailed_info_array, contro
                    int(settings['Commissioned Spare'] == 'Yes'))
         add_metric('pd_emergency_spare', pd_baselabel, int(settings['Emergency Spare'] == 'Yes'))
         pd_info_label += ',firmware="{0}"'.format(attributes['Firmware Revision'].strip())
+        if 'SN' in attributes:
+            pd_info_label += ',serial="{0}"'.format(attributes['SN'].strip())
     except KeyError:
         pass
     add_metric('pd_info', pd_info_label, 1)


### PR DESCRIPTION
Helpful for detecting whether a drive has been unplugged and put back in, or replaced with a different drive.

Signed-off-by: Brian Candler <b.candler@pobox.com>