### PR TITLE
Fixes to md_info

### DIFF
--- a/md_info.sh
+++ b/md_info.sh
@@ -2,6 +2,7 @@
 set -eu
 
 for MD_DEVICE in /dev/md/*; do
+  if [ -b "$MD_DEVICE" ]; then
   # Subshell to avoid eval'd variables from leaking between iterations
   (
     # Resolve symlink to discover device, e.g. /dev/md127
@@ -53,4 +54,5 @@ for MD_DEVICE in /dev/md/*; do
     # NOTE: Metadata version is a label rather than a separate metric because the version can be a string
     echo "node_md_info{md_device=\"${MD_DEVICE_NUM}\", md_name=\"${MD_DEVICE}\", raid_level=\"${MD_LEVEL}\", md_metadata_version=\"${MD_METADATA_VERSION}\"} 1"
   )
+  fi
 done

--- a/md_info_detail.sh
+++ b/md_info_detail.sh
@@ -7,6 +7,7 @@
 set -eu
 
 for MD_DEVICE in /dev/md/*; do
+  if [ -b "$MD_DEVICE" ]; then
   # Subshell to avoid eval'd variables from leaking between iterations
   (
     # Resolve symlink to discover device, e.g. /dev/md127
@@ -84,4 +85,5 @@ for MD_DEVICE in /dev/md/*; do
     done  <<< "$MDADM_DETAIL_OUTPUT"
     echo "} 1"
   )
+  fi
 done

--- a/md_info_detail.sh
+++ b/md_info_detail.sh
@@ -75,7 +75,7 @@ for MD_DEVICE in /dev/md/*; do
       # Filter for lines with a ":", to use for Key/Value pairs in labels
       if echo "$line" | grep -E -q ":" ; then
         # Exclude lines with these keys, as they're values are numbers that increment up and captured in individual metrics above
-        if echo "$line" | grep -E -qv "^/|Array Size|Used Dev Size|Events|Update Time" ; then
+        if echo "$line" | grep -E -qv "^/|Array Size|Used Dev Size|Events|Update Time|Check Status|Rebuild Status" ; then
           echo -n ", "
           MDADM_DETAIL_KEY=$(echo "$line" | cut -d ":" -f 1 | tr -cd '[a-zA-Z0-9]._-')
           MDADM_DETAIL_VALUE=$(echo "$line" | cut -d ":" -f 2- | sed 's:^ ::')

--- a/md_info_detail.sh
+++ b/md_info_detail.sh
@@ -75,7 +75,7 @@ for MD_DEVICE in /dev/md/*; do
       # Filter for lines with a ":", to use for Key/Value pairs in labels
       if echo "$line" | grep -E -q ":" ; then
         # Exclude lines with these keys, as they're values are numbers that increment up and captured in individual metrics above
-        if echo "$line" | grep -E -qv "Array Size|Used Dev Size|Events|Update Time" ; then
+        if echo "$line" | grep -E -qv "^/|Array Size|Used Dev Size|Events|Update Time" ; then
           echo -n ", "
           MDADM_DETAIL_KEY=$(echo "$line" | cut -d ":" -f 1 | tr -cd '[a-zA-Z0-9]._-')
           MDADM_DETAIL_VALUE=$(echo "$line" | cut -d ":" -f 2- | sed 's:^ ::')


### PR DESCRIPTION
1. Skip objects in /dev/md/ which are not block devices (required for CentOS 6)
2. Filter out "/dev/mdXXX:" header line from `mdadm --detail` output, which results in blank label such as `devmdXXX=""`
3. Remove CheckStatus and RebuildStatus label during RAID scrubs/rebuilds (e.g. `CheckStatus="75% complete"`) - fixes #25