### PR TITLE
Dedup attributes

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -276,7 +276,7 @@ def collect_ata_metrics(device):
         # Attributes such as 194 Temperature_Celsius reported by my SSD
         # are in the format of "36 (Min/Max 24/40)" which can't be expressed
         # properly as a prometheus metric.
-        m = re.match('^(\d+)', ' '.join(entry['raw_value']))
+        m = re.match(r'^(\d+)', ' '.join(entry['raw_value']))
         if not m:
             continue
         entry['raw_value'] = m.group(1)

--- a/smartmon.py
+++ b/smartmon.py
@@ -121,12 +121,10 @@ def smart_ctl(*args, check=True):
     Returns:
         (str) Data piped to stdout by the smartctl subprocess.
     """
-    try:
-        return subprocess.run(
-            ['smartctl', *args], stdout=subprocess.PIPE, check=check
-        ).stdout.decode('utf-8')
-    except subprocess.CalledProcessError as e:
-        return e.output.decode('utf-8')
+    return subprocess.run(
+        ['smartctl', *args], stdout=subprocess.PIPE, check=check
+    ).stdout.decode('utf-8')
+
 
 def smart_ctl_version():
     return smart_ctl('-V').split('\n')[0].split()[1]
@@ -241,12 +239,9 @@ def collect_device_health_self_assessment(device):
     Yields:
         (Metric) Device health self assessment.
     """
-    out = smart_ctl('--health', *device.smartctl_select())
+    out = smart_ctl('--health', *device.smartctl_select(), check=False)
 
-    if self_test_re.search(out):
-        self_assessment_passed = True
-    else:
-        self_assessment_passed = False
+    self_assessment_passed = bool(self_test_re.search(out))
 
     yield Metric(
         'device_smart_healthy', device.base_labels, self_assessment_passed)


### PR DESCRIPTION
Pull request contains a few fixes:

* A previous change introduced a regression and cause a few SMART tests to fail. (namely device_is_active) This is fixed by allowing `smart_ctl` to fail again and opt out of error checks explicitly. 
* Small fix that caused python to interpret `\d` as en escape sequence.
* Add a `--wakeup-disks` command line argument to optionally wake up disks and query them for their SMART values.
* deduplicate SMART attributes when reporting them as metrics to prometheus.

The last change is the most controversial one I assume. I found a disk that reports the same attribute name under different IDs.

```
171 Program_Fail_Count      0x000a   000   000   000    Old_age   Always       -       7
181 Program_Fail_Count      0x000a   000   000   000    Old_age   Always       -       7
```

This causes the script to produce the output

```
smartmon_attr_value{name="program_fail_count",disk="/dev/pass1"} 0
smartmon_attr_value{name="program_fail_count",disk="/dev/pass1"} 0
```

which in turn causes prometheus to not be happy about it.

The fix causes the script to deduplicate these attribute names and only report them once. A different approach would probably have been to change the output altogether and prepend the attribute id in front of the name so that `program_fail_count` becomes `attr171_program_fail_count`. This approach would be backwards incompatible though.

Please let me know what you think.