### PR TITLE
ADD storcli detailed CacheVault metrics

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -147,7 +147,13 @@ def handle_cachevault(args, controller_index, response):
             pass
 
         try:
-            amount, units = search_property(response, 'GasGaugeStatus', 'Capacitance').split(' ', 1)
+            # Another nasty hack as the output format is not consistent for certain values, e.g. 0 and 100
+            capacitance = search_property(response, 'GasGaugeStatus', 'Capacitance')
+            if '%' in capacitance:
+                amount, units = capacitance.split(' ', 1)
+            else:
+                amount = capacitance
+                units = '%'
             add_metric('cv_gas_capacitance', baselabel + ',units="{0}"'.format(units), amount)
         except ValueError:
             pass

--- a/storcli.py
+++ b/storcli.py
@@ -267,8 +267,10 @@ def handle_megaraid_controller(response):
     (controller_index, baselabel) = get_basic_controller_info(response)
 
     # BBU Status value is not explained in the schema, see note in the header.
-    add_metric('bbu_status', baselabel,
-               int(response['Status']['BBU Status']))
+    try:
+        add_metric('bbu_status', baselabel, int(response['Status']['BBU Status']))
+    except:
+        pass
 
     add_metric('degraded', baselabel, int(response['Status']['Controller Status'] == 'Degraded'))
     add_metric('failed', baselabel, int(response['Status']['Controller Status'] == 'Failed'))


### PR DESCRIPTION
There doesn't seem to be any documentation around the "BBU Status" field and, unlike what @mulbc describes on 1b98db9fa72abe93541fb1a7140388504601e303, we experience it now in several states other than [0,32] (16, 64, etc) which we cannot understand; and they last for random multiple days durations.

I therefore followed his suggestion of parsing the detailed output, but only for CacheVault, not BBU. I cannot find now a machine with BBU, so that'll come later.
