### PR TITLE
yum.sh fixes

### DIFF
--- a/yum.sh
+++ b/yum.sh
@@ -6,7 +6,7 @@
 # 
 # Based on apt.sh by Ben Kochie <superq@gmail.com>
 
-upgrades=$(/usr/bin/yum -q check-updates | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute { print }' | egrep '^\w+\.\w+' | awk '{print $3}' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
+upgrades=$(/usr/bin/yum -q check-update | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute { print }' | egrep '^\w+\.\w+' | awk '{print $3}' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
 
 echo '# HELP yum_upgrades_pending Yum package pending updates by origin.'
 echo '# TYPE yum_upgrades_pending gauge'

--- a/yum.sh
+++ b/yum.sh
@@ -6,7 +6,7 @@
 # 
 # Based on apt.sh by Ben Kochie <superq@gmail.com>
 
-upgrades=$(/usr/bin/yum -q check-update | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute { print }' | egrep '^\w+\.\w+' | awk '{print $3}' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
+upgrades=$(/usr/bin/yum -q check-update | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute && /^[[:print:]]+\.[[:print:]]+/ { print $3 }' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
 
 echo '# HELP yum_upgrades_pending Yum package pending updates by origin.'
 echo '# TYPE yum_upgrades_pending gauge'


### PR DESCRIPTION
* Change "yum check-updates" to "yum check-update" to work with CentOS 6+
* Allow - and + in package names; simplify awk pipeline

Fixes #14