### PR TITLE
Split up yum.sh script long line

### DIFF
--- a/yum.sh
+++ b/yum.sh
@@ -6,7 +6,27 @@
 # 
 # Based on apt.sh by Ben Kochie <superq@gmail.com>
 
-upgrades=$(/usr/bin/yum -q check-update | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute && /^[[:print:]]+\.[[:print:]]+/ { print $3 }' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
+set -u -o pipefail
+
+filter_awk_script='
+BEGIN { mute=1 }
+/Obsoleting Packages/ {
+  mute=0
+}
+mute && /^[[:print:]]+\.[[:print:]]+/ {
+  print $3
+}
+'
+
+check_upgrades() {
+  /usr/bin/yum -q check-update |
+    awk "${filter_awk_script}" |
+    sort |
+    uniq -c |
+    awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}'
+}
+
+upgrades=$(check_upgrades)
 
 echo '# HELP yum_upgrades_pending Yum package pending updates by origin.'
 echo '# TYPE yum_upgrades_pending gauge'
@@ -15,4 +35,3 @@ if [[ -n "${upgrades}" ]] ; then
 else
   echo 'yum_upgrades_pending{origin=""} 0'
 fi
-


### PR DESCRIPTION
Break up the long pipeline in the yum.sh script to make it easier to
read.

Add bash sanity settings.

Signed-off-by: Ben Kochie <superq@gmail.com>