### PR TITLE
Adds amp/current support to ipmitool

### DIFF
--- a/ipmitool
+++ b/ipmitool
@@ -31,12 +31,14 @@ BEGIN {
 	# Friendly description of the type of sensor for HELP.
 	help["temperature_celsius"] = "Temperature";
 	help["volts"] = "Voltage";
+	help["amps"] = "Amps";
 	help["power_watts"] = "Power";
 	help["speed_rpm"] = "Fan";
 	help["status"] = "Chassis status";
 
 	temperature_celsius["metric_count"] = 0;
 	volts["metric_count"] = 0;
+	amps["amps"] = 0;
 	power_watts["metric_count"] = 0;
 	speed_rpm["metric_count"] = 0;
 	status["metric_count"] = 0;
@@ -65,6 +67,11 @@ $3 ~ /Volts/ {
 	volts["metric_count"]++;
 }
 
+$3 ~ /Amps/ {
+	amps[$1] = $2;
+	amps["metric_count"]++;
+}
+
 $3 ~ /Watts/ {
 	power_watts[$1] = $2;
 	power_watts["metric_count"]++;
@@ -83,6 +90,7 @@ $3 ~ /discrete/ {
 END {
 	export(temperature_celsius, "temperature_celsius");
 	export(volts, "volts");
+	export(amps, "amps");
 	export(power_watts, "power_watts");
 	export(speed_rpm, "speed_rpm");
 	export(status, "status");


### PR DESCRIPTION
I have a few sensors that reports current (Amps).

`$ sudo ipmitool sensor | grep -i amps
VR_P0_IOUT       | 103.000    | Amps       | ok    | na        | na        | na        | 228.000   | 248.000   | na
VR_DIMMG0_IOUT   | 35.000     | Amps       | ok    | na        | na        | na        | 228.000   | 248.000   | na
VR_DIMMG1_IOUT   | 35.000     | Amps       | ok    | na        | na        | na        | 228.000   | 248.000   | na`