### PR TITLE
smartmon.py: fix parse error

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -286,6 +286,12 @@ def collect_ata_metrics(device):
             continue
         entry['raw_value'] = m.group(1)
 
+        # Some device models report "---" in the threshold value where most
+        # devices would report "000". We do the substitution here because
+        # downstream code expects values to be convertable to integer.
+        if entry['threshold'] == '---':
+            entry['threshold'] = '0'
+
         if entry['name'] in smart_attributes_whitelist and entry['name'] not in seen:
             labels = {
                 'name': entry['name'],


### PR DESCRIPTION
Some device models report "---" in the threshold value where most devices would report "000".
This was crashing the program with a parse exception.