### PR TITLE
Do not interrupt processing if Cachevault_Info is missing

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -109,7 +109,7 @@ def handle_megaraid_controller(response):
     add_metric('ports', baselabel, response['HwCfg']['Backend Port Count'])
     add_metric('scheduled_patrol_read', baselabel,
                int('hrs' in response['Scheduled Tasks']['Patrol Read Reoccurrence']))
-    for cvidx, cvinfo in enumerate(response['Cachevault_Info']):
+    for cvidx, cvinfo in enumerate(response.get('Cachevault_Info', [])):
         add_metric('cv_temperature',
                    baselabel + ',cvidx="' + str(cvidx) + '"',
                    int(cvinfo['Temp'].replace('C', ''))


### PR DESCRIPTION
When using perccli with missing Cachevault_Info the script is interrupted on an early stage. This PR is to ignore missing key and continue processing.