### PR TITLE
Fix typo in temperature metric (Closes #46)

### DIFF
--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -54,7 +54,7 @@ for device in ${device_list}; do
 
   # The temperature value in JSON is in Kelvin, we want Celsius
   value_temperature="$(echo "$json_check" | jq '.temperature - 273')"
-  echo "temperature_celcius{device=\"${disk}\"} ${value_temperature}"
+  echo "temperature_celsius{device=\"${disk}\"} ${value_temperature}"
 
   value_available_spare="$(echo "$json_check" | jq '.avail_spare / 100')"
   echo "available_spare_ratio{device=\"${disk}\"} ${value_available_spare}"


### PR DESCRIPTION
I guess this is a breaking change as the metric name will go from:

`temperature_celcius` to `temperature_celsius`