### PR TITLE
smartmon.py: Fixed check if device is active.

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -126,7 +126,7 @@ def smart_ctl(*args, check=True):
             ['smartctl', *args], stdout=subprocess.PIPE, check=check
         ).stdout.decode('utf-8')
     except subprocess.CalledProcessError as e:
-        return e.output.decode('utf-8')
+        raise e
 
 def smart_ctl_version():
     return smart_ctl('-V').split('\n')[0].split()[1]


### PR DESCRIPTION
smartctl --nockeck standby throughs an exception with errorcode "2" in case the device is not active. Since this exception or the errorcode is not passed to the calling function the device was recognized to be active in this case. Fixed it by re-raising exception.