### PR TITLE
Have yum.sh correctly deal with long lines

### DIFF
--- a/yum.sh
+++ b/yum.sh
@@ -20,7 +20,7 @@ mute && /^[[:print:]]+\.[[:print:]]+/ {
 '
 
 check_upgrades() {
-  /usr/bin/yum -q check-update |
+  /usr/bin/yum -q check-update | /usr/bin/xargs -n3 |
     awk "${filter_awk_script}" |
     sort |
     uniq -c |


### PR DESCRIPTION
When yum output is redirected, it wraps to 80 columns (https://bugzilla.redhat.com/show_bug.cgi?id=584525) - for long lines, this results in yum_upgrades_pending metrics with origin="".

Adding xargs to the pipeline corrects things so awk works as intended.