### PR TITLE
Add alternate name for SMART 187

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -59,6 +59,7 @@ temperature_internal
 total_lbas_read
 total_lbas_written
 udma_crc_error_count
+uncorrectable_error_cnt
 unsafe_shutdown_count
 unused_rsvd_blk_cnt_tot
 wear_leveling_count


### PR DESCRIPTION
SMART attribute 187 is known by either Reported_Uncorrect or Uncorrectable_Error_Cnt.