### PR TITLE
mellanox_hca_temp: Rename hca_device label to device

### DIFF
--- a/mellanox_hca_temp
+++ b/mellanox_hca_temp
@@ -46,7 +46,7 @@ for dev in /sys/class/infiniband/*; do
     # get temperature
     if temperature="$(mget_temp_ext -d "${device}")"; then
         # output
-        echo "node_infiniband_hca_temp_celsius{hca_device=\"${device}\"} ${temperature//[[:space:]]/}"
+        echo "node_infiniband_hca_temp_celsius{device=\"${device}\"} ${temperature//[[:space:]]/}"
     else
         echo "${0##*/}: Failed to get temperature from InfiniBand HCA '${device}'!" >&2
     fi


### PR DESCRIPTION
To be consistent with the `node_infiniband_*` labels (e.g. `node_infiniband_info`) from the Prometheus node exporter, rename the
metric label `hca_device` to `device`. Then you can write an alert to check for missing temperature metrics:

```
node_infiniband_info unless on (instance, device) node_infiniband_hca_temp_celsius
```

Signed-off-by: Benjamin Drung <benjamin.drung@cloud.ionos.com>