### PR TITLE
nvme_metrics.sh: Support for more than 10 NVMe and use JSON output of nvme

### DIFF
--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -50,7 +50,7 @@ device_list="$(nvme list | awk '/^\/dev/{print $1}')"
 # Loop through the NVMe devices
 for device in ${device_list}; do
   json_check="$(nvme smart-log -o json "${device}")"
-  disk="$(echo "${device}" | cut -c6-10)"
+  disk="${device##*/}"
 
   # The temperature value in JSON is in Kelvin, we want Celsius
   value_temperature="$(echo "$json_check" | jq '.temperature - 273')"

--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -45,7 +45,7 @@ nvme_version="$(nvme version | awk '$1 == "nvme" {print $3}')"
 echo "nvmecli{version=\"${nvme_version}\"} 1" | format_output
 
 # Get devices
-device_list="$(nvme list | awk '/^\/dev/{print $1}')"
+device_list="$(nvme list -o json | jq -r '.Devices | .[].DevicePath')"
 
 # Loop through the NVMe devices
 for device in ${device_list}; do


### PR DESCRIPTION
The `cut` command assumes that `device` is in the format `/dev/nvmeX` and will fail if the NVMe number is higher than 9 (e.g. `/dev/nvme10`).

Therefore use a built-in shell method to calculate the basename of the device. (Closes #18)

Parsing the human-readable output of nvme with awk is fragile since the output format is not promised to be stable. Therefore use the JSON output format to make the script more robust.
