### PR TITLE
Update tw_cli.py to Python 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,3 @@ max-line-length = 100
 exclude=
   .git,
   .circleci,
-  # TODO: tw_cli.py needs to be updated for Python 3.
-  tw_cli.py

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -115,7 +115,7 @@ def test_arrays(verbosity, warn_true=False):
     """Tests all the RAID arrays on all the 3ware controllers on the local machine"""
     lines = run("show")
     # controllers = [line.split()[0] for line in lines]
-    controllers = [line.split()[0] for line in lines if line and line[0] == "c"]
+    controllers = [line.split()[0] for line in lines if line.startswith('c')]
 
     for controller in controllers:
         unit_lines = run("/%s show unitstatus" % controller)
@@ -241,7 +241,7 @@ def collect_controller(verbosity):
         'ACHIP Version':    {'label': 'achip', 'parser': None},
     }
     lines = run("show")
-    controllers = [line.split()[0] for line in lines if line and line[0] == "c"]
+    controllers = [line.split()[0] for line in lines if line.startswith('c')]
 
     for controller in controllers:
         collect_details('/' + controller, CTRL_DETAILS, 'controller_info',

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Prometheus exporter for 3ware RAID controllers
+# Prometheus node_exporter textfile collector for 3ware RAID controllers
 #
 # Half of it based on "Nagios Plugin for 3ware RAID" from "Hari Sekhon",
 # Ref: http://github.com/harisekhon/nagios-plugins
@@ -8,15 +8,14 @@
 #
 # (c) 2019, Nuno Tavares <n.tavares@portavita.eu>
 #
-# You can find the latest version in:
+# You can find the latest version at:
 # https://github.com/ntavares/node-exporter-textfile-collector-scripts
 #
 
-"""Nagios plugin to test the state of all 3ware raid arrays and/or drives
-   on all 3ware controllers on the local machine. Requires the tw_cli program
-   written by 3ware, which should be called tw_cli_64 if running on a 64-bit
-   system. May be remotely executed via any of the standard remote nagios
-   execution mechanisms"""
+"""Nagios plugin to test the state of all 3ware RAID arrays and / or drives on all 3ware controllers
+on the local machine. Requires the tw_cli program written by 3ware, which should be called tw_cli_64
+if running on a 64-bit system. May be remotely executed via any of the standard remote nagios
+execution mechanisms"""
 
 import copy
 import os
@@ -59,13 +58,13 @@ BIN = None
 
 
 def _set_twcli_binary():
-    """ set the path to the twcli binary"""
+    """Set the path to the twcli binary"""
     global BIN
     BIN = '/usr/sbin/tw_cli'
 
 
 def run(cmd, stripOutput=True):
-    """runs a system command and returns stripped output"""
+    """Runs a system command and returns stripped output"""
     if not cmd:
         exit_error("internal python error - no cmd supplied for 3ware utility")
     try:
@@ -90,7 +89,7 @@ def run(cmd, stripOutput=True):
         exit_error("No output from 3ware utility")
 
     output = str(stdout).split("\n")
-    # strip command prompt, since we're running an interactive CLI shell
+    # Strip command prompt, since we're running an interactive CLI shell
     output[0] = re.sub(r'//.*?> ', '', output[0])
 
     if output[1] == "No controller found.":
@@ -107,17 +106,13 @@ def run(cmd, stripOutput=True):
 
 
 def test_all(verbosity, warn_true=False):
-    """Calls the raid and drive testing functions"""
-
+    """Calls the RAID and drive testing functions"""
     test_arrays(verbosity, warn_true)
-
     test_drives(verbosity, warn_true)
 
 
 def test_arrays(verbosity, warn_true=False):
-    """Tests all the raid arrays on all the 3ware controllers on
-    the local machine"""
-
+    """Tests all the RAID arrays on all the 3ware controllers on the local machine"""
     lines = run("show")
     # controllers = [line.split()[0] for line in lines]
     controllers = [line.split()[0] for line in lines if line and line[0] == "c"]
@@ -160,9 +155,7 @@ def test_arrays(verbosity, warn_true=False):
 
 
 def test_drives(verbosity, warn_true=False):
-    """Tests all the drives on the all the 3ware raid controllers
-    on the local machine"""
-
+    """Tests all the drives on the all the 3ware RAID controllers on the local machine"""
     lines = run("show")
     controllers = []
     for line in lines:
@@ -211,13 +204,11 @@ def _parse_yes_ok_on(val):
     return 0
 
 
-"""Generic function to parse key = value lists, based on a detailsMap which
-   selects the fields top parse. injectedLabels is just baseline labels to be included.
-   Note that the map may list both labels to append to a catchall 'metric', or individual
-   metrics, whose name overrides 'metric' and will contain injectedLabels."""
-
-
 def collect_details(cmdprefix, detailsMap, metric, injectedLabels, verbosity):
+    """Generic function to parse key = value lists, based on a detailsMap which selects the fields
+    to parse. injectedLabels is just baseline labels to be included. Note that the map may list both
+    labels to append to a catchall 'metric', or individual metrics, whose name overrides 'metric'
+    and will contain injectedLabels."""
     lines = run("%s show all" % cmdprefix, False)
     labels = copy.copy(injectedLabels)
     for line in lines:
@@ -231,7 +222,7 @@ def collect_details(cmdprefix, detailsMap, metric, injectedLabels, verbosity):
             if k in detailsMap:
                 if detailsMap[k]['parser']:
                     v = detailsMap[k]['parser'](v)
-                # if this field is meant for a separate metric, do it
+                # If this field is meant for a separate metric, do it
                 if 'metric' in detailsMap[k]:
                     add_metric(detailsMap[k]['metric'], injectedLabels, v)
                 else:
@@ -299,9 +290,7 @@ def collect_bbu(controller, verbosity):
 
 
 def main():
-    """Parses command line options and calls the function to
-    test the arrays/drives"""
-
+    """Parses command line options and calls the function to test the arrays/drives"""
     parser = OptionParser()
 
     parser.add_option("-a",

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Prometheus exporter for 3ware RAID controllers
 #
@@ -37,13 +37,13 @@ METRICS = {}
 METRIC_PREFIX = 'tw_cli'
 
 def exit_error(msg):
-    print METRIC_PREFIX + "_cli_error{message=\"" + str(msg) + "\"}\t1"
+    print(METRIC_PREFIX + "_cli_error{message=\"" + str(msg) + "\"}\t1")
     sys.exit(1)
 
 def exit_clean():
     global METRICS
     for mk, mv in METRICS.items():
-        print METRIC_PREFIX + '_' + mk + "\t" + str(mv)
+        print(METRIC_PREFIX + '_' + mk + "\t" + str(mv))
     sys.exit(0)
 
 def add_metric(metric, labels, value):
@@ -71,7 +71,7 @@ def run(cmd, stripOutput=True):
         exit_error("internal python error - no cmd supplied for 3ware utility")
     try:
         process = Popen(BIN, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-    except OSError, error:
+    except OSError as error:
         error = str(error)
         if error == "No such file or directory":
             exit_error("Cannot find 3ware utility '%s'" % BIN)
@@ -84,7 +84,7 @@ def run(cmd, stripOutput=True):
 
     try:
         stdout, stderr = process.communicate(cmd)
-    except OSError, error:
+    except OSError as error:
         exit_error("unable to communicate with 3ware utility - %s" % error)
 
 
@@ -128,8 +128,8 @@ def test_arrays(verbosity, warn_true=False):
         unit_lines = run("/%s show unitstatus" % controller)
         if verbosity >= 3:
             for unit_line in unit_lines:
-                print unit_line
-            print
+                print(unit_line)
+            print()
 
         for unit_line in unit_lines:
             unit_line = unit_line.split()
@@ -179,8 +179,8 @@ def test_drives(verbosity, warn_true=False):
 
         if verbosity >= 3:
             for drive_line in drive_lines:
-                print drive_line
-            print
+                print(drive_line)
+            print()
 
         for drive_line in drive_lines:
             drive_line = drive_line.split()
@@ -222,12 +222,12 @@ def collect_details(cmdprefix, detailsMap, metric, injectedLabels, verbosity):
     for line in lines:
         if re.match('^' + cmdprefix + ' (.+?)= (.+?)$', line):
             if verbosity >= 3:
-                print line
+                print(line)
             result = re.split('\S+ (.+?)= (.+?)$', line)
             #print "RESULT: " + str(result)
             k = result[1].strip()
             v = result[2].strip()
-            if k in detailsMap.keys():
+            if k in detailsMap:
                 if detailsMap[k]['parser']:
                     v = detailsMap[k]['parser'](v)
                 # if this field is meant for a separate metric, do it
@@ -356,17 +356,17 @@ def main():
     incl_info    = options.incl_info
 
     if version:
-        print __version__
+        print(__version__)
         sys.exit(OK)
 
     if arrays_only and drives_only:
-        print "You cannot use the -a and -d switches together, they are",
-        print "mutually exclusive\n"
+        print("You cannot use the -a and -d switches together, they are", end=' ')
+        print("mutually exclusive\n")
         parser.print_help()
         sys.exit(1)
     elif drives_only and warn_true:
-        print "You cannot use the -d and -w switches together"
-        print "Array warning states are invalid when testing only drives\n"
+        print("You cannot use the -d and -w switches together")
+        print("Array warning states are invalid when testing only drives\n")
         parser.print_help()
         sys.exit(1)
 
@@ -387,5 +387,5 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print "Caught Control-C..."
+        print("Caught Control-C...")
         sys.exit(1)

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -31,14 +31,14 @@ METRIC_PREFIX = 'tw_cli'
 
 
 def exit_error(msg):
-    print(METRIC_PREFIX + "_cli_error{message=\"" + str(msg) + "\"}\t1")
+    print(METRIC_PREFIX + '_cli_error{message="' + str(msg) + '"}\t1')
     sys.exit(1)
 
 
 def exit_clean():
     global METRICS
     for mk, mv in METRICS.items():
-        print(METRIC_PREFIX + '_' + mk + "\t" + str(mv))
+        print(METRIC_PREFIX + '_' + mk + '\t' + str(mv))
     sys.exit(0)
 
 
@@ -66,7 +66,7 @@ def _set_twcli_binary():
 def run(cmd, stripOutput=True):
     """Runs a system command and returns stripped output"""
     if not cmd:
-        exit_error("internal python error - no cmd supplied for 3ware utility")
+        exit_error("Internal python error - no cmd supplied for 3ware utility")
     try:
         process = Popen(BIN, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
     except OSError as error:
@@ -74,7 +74,7 @@ def run(cmd, stripOutput=True):
         if error == "No such file or directory":
             exit_error("Cannot find 3ware utility '%s'" % BIN)
         else:
-            exit_error("error trying to run 3ware utility - %s" % error)
+            exit_error("Error trying to run 3ware utility - %s" % error)
 
     if process.poll():
 
@@ -83,12 +83,12 @@ def run(cmd, stripOutput=True):
     try:
         stdout, stderr = process.communicate(cmd)
     except OSError as error:
-        exit_error("unable to communicate with 3ware utility - %s" % error)
+        exit_error("Unable to communicate with 3ware utility - %s" % error)
 
     if not stdout:
         exit_error("No output from 3ware utility")
 
-    output = str(stdout).split("\n")
+    output = str(stdout).split('\n')
     # Strip command prompt, since we're running an interactive CLI shell
     output[0] = re.sub(r'//.*?> ', '', output[0])
 
@@ -96,7 +96,7 @@ def run(cmd, stripOutput=True):
         exit_error("No 3ware controllers were found on this machine")
 
     if process.returncode != 0:
-        stderr = str(stdout).replace("\n", " ")
+        stderr = str(stdout).replace('\n', ' ')
         exit_error("3ware utility returned an exit code of %s - %s" % (process.returncode, stderr))
 
     if stripOutput:
@@ -113,12 +113,12 @@ def test_all(verbosity, warn_true=False):
 
 def test_arrays(verbosity, warn_true=False):
     """Tests all the RAID arrays on all the 3ware controllers on the local machine"""
-    lines = run("show")
+    lines = run('show')
     # controllers = [line.split()[0] for line in lines]
     controllers = [line.split()[0] for line in lines if line.startswith('c')]
 
     for controller in controllers:
-        unit_lines = run("/%s show unitstatus" % controller)
+        unit_lines = run('/%s show unitstatus' % controller)
         if verbosity >= 3:
             for unit_line in unit_lines:
                 print(unit_line)
@@ -129,34 +129,34 @@ def test_arrays(verbosity, warn_true=False):
             state = unit_line[2]
             unit = int(unit_line[0][1:])
             raid = unit_line[1]
-            add_metric('array_info', {"controller": controller[1:], "unit": unit, "state": state,
-                       "raid": raid}, 1)
+            add_metric('array_info', {'controller': controller[1:], 'unit': unit, 'state': state,
+                       'raid': raid}, 1)
 
-            if state == "OK":
-                add_metric('array_status', {"controller": controller[1:], "unit": unit,
-                           "state": state}, 1)
+            if state == 'OK':
+                add_metric('array_status', {'controller': controller[1:], 'unit': unit,
+                           'state': state}, 1)
                 continue
-            elif state in ("REBUILDING", "VERIFY-PAUSED", "VERIFYING", "INITIALIZING"):
-                if state in ("VERIFY-PAUSED", "VERIFYING", "INITIALIZING"):
+            elif state in ('REBUILDING', 'VERIFY-PAUSED', 'VERIFYING', 'INITIALIZING'):
+                if state in ('VERIFY-PAUSED', 'VERIFYING', 'INITIALIZING'):
                     percent_complete = unit_line[4]
                 else:
                     percent_complete = unit_line[3]
 
                 if warn_true:
-                    add_metric('array_status', {"controller": controller[1:], "unit": unit,
-                               "state": state, "pct": percent_complete}, 0)
+                    add_metric('array_status', {'controller': controller[1:], 'unit': unit,
+                               'state': state, 'pct': percent_complete}, 0)
                 else:
-                    add_metric('array_status', {"controller": controller[1:], "unit": unit,
-                               "state": state, "pct": percent_complete}, 1)
+                    add_metric('array_status', {'controller': controller[1:], 'unit': unit,
+                               'state': state, 'pct': percent_complete}, 1)
 
             else:
-                add_metric('array_status', {"controller": controller[1:], "unit": unit,
-                           "state": state}, 0)
+                add_metric('array_status', {'controller': controller[1:], 'unit': unit,
+                           'state': state}, 0)
 
 
 def test_drives(verbosity, warn_true=False):
     """Tests all the drives on the all the 3ware RAID controllers on the local machine"""
-    lines = run("show")
+    lines = run('show')
     controllers = []
     for line in lines:
         parts = line.split()
@@ -164,7 +164,7 @@ def test_drives(verbosity, warn_true=False):
             controllers.append(parts[0])
 
     for controller in controllers:
-        drive_lines = run("/%s show drivestatus" % controller)
+        drive_lines = run('/%s show drivestatus' % controller)
 
         if verbosity >= 3:
             for drive_line in drive_lines:
@@ -175,22 +175,22 @@ def test_drives(verbosity, warn_true=False):
             drive_line = drive_line.split()
             state = drive_line[1]
             drive = drive_line[0]
-            if drive[0] == "d":
+            if drive[0] == 'd':
                 drive = drive[1:]
             array = drive_line[2]
-            if array[0] == "u":
+            if array[0] == 'u':
                 array = array[1:]
-            if state == "OK" or state == "NOT-PRESENT":
-                add_metric('drive_status', {"controller": controller[1:], "drive": drive,
-                           "array": array, "state": state}, 1)
+            if state in ('OK', 'NOT-PRESENT'):
+                add_metric('drive_status', {'controller': controller[1:], 'drive': drive,
+                           'array': array, 'state': state}, 1)
                 continue
             if not warn_true and state in ('VERIFYING', 'REBUILDING', 'INITIALIZING'):
-                add_metric('drive_status', {"controller": controller[1:], "drive": drive,
-                           "array": array, "state": state}, 1)
+                add_metric('drive_status', {'controller': controller[1:], 'drive': drive,
+                           'array': array, 'state': state}, 1)
                 continue
             else:
-                add_metric('drive_status', {"controller": controller[1:], "drive": drive,
-                           "array": array, "state": state}, 0)
+                add_metric('drive_status', {'controller': controller[1:], 'drive': drive,
+                           'array': array, 'state': state}, 0)
 
 
 def _parse_temperature(val):
@@ -199,7 +199,7 @@ def _parse_temperature(val):
 
 
 def _parse_yes_ok_on(val):
-    if val in ['OK', 'Yes', 'On']:
+    if val in ('OK', 'Yes', 'On'):
         return 1
     return 0
 
@@ -209,7 +209,7 @@ def collect_details(cmdprefix, detailsMap, metric, injectedLabels, verbosity):
     to parse. injectedLabels is just baseline labels to be included. Note that the map may list both
     labels to append to a catchall 'metric', or individual metrics, whose name overrides 'metric'
     and will contain injectedLabels."""
-    lines = run("%s show all" % cmdprefix, False)
+    lines = run('%s show all' % cmdprefix, False)
     labels = copy.copy(injectedLabels)
     for line in lines:
         if re.match('^' + cmdprefix + ' (.+?)= (.+?)$', line):
@@ -240,12 +240,12 @@ def collect_controller(verbosity):
         'PCHIP Version':    {'label': 'pchip', 'parser': None},
         'ACHIP Version':    {'label': 'achip', 'parser': None},
     }
-    lines = run("show")
+    lines = run('show')
     controllers = [line.split()[0] for line in lines if line.startswith('c')]
 
     for controller in controllers:
         collect_details('/' + controller, CTRL_DETAILS, 'controller_info',
-                        {"controller": controller[1:]}, verbosity)
+                        {'controller': controller[1:]}, verbosity)
         collect_bbu(controller, verbosity)
         collect_drives(controller, verbosity)
 
@@ -266,7 +266,7 @@ def collect_drives(controller, verbosity):
         drive_line = drive_line.split()
         drive = drive_line[0]
         collect_details('/' + controller + '/' + drive, DRIVE_DETAILS, 'drive_info',
-                        {"controller": controller[1:], 'drive': drive}, verbosity)
+                        {'controller': controller[1:], 'drive': drive}, verbosity)
 
 
 def collect_bbu(controller, verbosity):
@@ -286,52 +286,52 @@ def collect_bbu(controller, verbosity):
                                        'parser': _parse_temperature},
     }
     collect_details('/' + controller + '/bbu', BBU_DETAILS, 'bbu_info',
-                    {"controller": controller[1:]}, verbosity)
+                    {'controller': controller[1:]}, verbosity)
 
 
 def main():
     """Parses command line options and calls the function to test the arrays/drives"""
     parser = OptionParser()
 
-    parser.add_option("-a",
-                      "--arrays-only",
-                      action="store_true",
-                      dest="arrays_only",
+    parser.add_option('-a',
+                      '--arrays-only',
+                      action='store_true',
+                      dest='arrays_only',
                       help="Only test the arrays. By default both arrays and drives are checked")
 
-    parser.add_option("-d",
-                      "--drives-only",
-                      action="store_true",
-                      dest="drives_only",
+    parser.add_option('-d',
+                      '--drives-only',
+                      action='store_true',
+                      dest='drives_only',
                       help="Only test the drives. By default both arrays and drives are checked")
 
-    parser.add_option("-w",
-                      "--warn-rebuilding",
-                      action="store_true",
-                      dest="warn_true",
+    parser.add_option('-w',
+                      '--warn-rebuilding',
+                      action='store_true',
+                      dest='warn_true',
                       help="Warn when an array or disk is Rebuilding, Initializing or Verifying. "
                       "You might want to do this to keep a closer eye on things. Also, these "
                       "conditions can affect performance so you might want to know this is going "
                       "on. Default is to not warn during these states as they are not usually "
                       "problems")
 
-    parser.add_option("-v",
-                      "--verbose",
-                      action="count",
-                      dest="verbosity",
+    parser.add_option('-v',
+                      '--verbose',
+                      action='count',
+                      dest='verbosity',
                       help="Verbose mode. Good for testing plugin. By default only one result line "
                       "is printed as per Nagios standards")
 
-    parser.add_option("-V",
-                      "--version",
-                      action="store_true",
-                      dest="version",
+    parser.add_option('-V',
+                      '--version',
+                      action='store_true',
+                      dest='version',
                       help="Print version number and exit")
 
-    parser.add_option("-I",
-                      "--info",
-                      action="store_true",
-                      dest="incl_info",
+    parser.add_option('-I',
+                      '--info',
+                      action='store_true',
+                      dest='incl_info',
                       help="Include detailed component info")
 
     (options, args) = parser.parse_args()
@@ -374,7 +374,7 @@ def main():
     exit_clean()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -18,19 +18,12 @@
    system. May be remotely executed via any of the standard remote nagios
    execution mechanisms"""
 
+import copy
 import os
 import re
 import sys
 from optparse import OptionParser
-import copy
-
-
-try:
-    from subprocess import Popen, PIPE, STDOUT
-except ImportError:
-    # Perhaps you are using a version of python older than 2.4?
-    print("CLI Parser error: Failed to import subprocess module.")
-    sys.exit(1)
+from subprocess import Popen, PIPE, STDOUT
 
 __version__ = '0.1.0'
 

--- a/tw_cli.py
+++ b/tw_cli.py
@@ -26,6 +26,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 __version__ = '0.1.0'
 
+BIN = None
 METRICS = {}
 METRIC_PREFIX = 'tw_cli'
 
@@ -49,12 +50,6 @@ def add_metric(metric, labels, value):
         labelstrs += ['{}="{}"'.format(lk, lv)]
     labelstr = ','.join(labelstrs)
     METRICS[metric + '{' + labelstr + '}'] = str(value)
-
-
-if os.geteuid() != 0:
-    exit_error("You must be root to run this plugin")
-
-BIN = None
 
 
 def _set_twcli_binary():
@@ -359,6 +354,9 @@ def main():
         print("Array warning states are invalid when testing only drives\n")
         parser.print_help()
         sys.exit(1)
+
+    if os.geteuid() != 0:
+        exit_error("You must be root to run this plugin")
 
     _set_twcli_binary()
 


### PR DESCRIPTION
Convert `tw_cli.py` textfile collector to Python 3 and address flake8 nags. Also do a few minor cleanups to docstrings, formatting, and simplify some if-statements.

Note that this script still uses `OptionParser`, which has been deprecated since Python 3.2. We could convert this to `ArgumentParser`, but this would raise our minimum supported Python version to 3.2 (which is still ancient). @SuperQ let me know if you want me to go ahead with that. The smartmon.py and storcli.py collectors already use `ArguementParser`, so one could "argue" that we already require Python 3.2 ;-)

This script still contains a few references to Nagios and associated terminology, as it was originally based on a very old Nagios plugin. Overall it could be substantially simplified and made more elegant by using modern Python 3 techniques, but without a 3ware card to test with, or a reliable way to mock the output of `tw_cli`, I am hesitant to do so.

According to Broadcom documentation, `storcli` can also be used to manage 3ware cards, so I'm not sure how much effort it is worth putting into this collector, considering that we have the storcli collector in reasonably good shape (and the JSON output of `storcli` is much more robust to parse).