### PR TITLE
btrfs_stats: detect empty lines in Python 3

### DIFF
--- a/btrfs_stats.py
+++ b/btrfs_stats.py
@@ -40,7 +40,7 @@ def get_btrfs_errors(mountpoint):
     if p.returncode != 0:
         raise RuntimeError("btrfs returned exit code %d" % p.returncode)
     for line in stdout.splitlines():
-        if line == '':
+        if not line:
             continue
         # Sample line:
         # [/dev/vdb1].flush_io_errs   0


### PR DESCRIPTION
The `line == ''` check doesn't work in Python 3, which uses bytestrings. Replace it with `not line`.

Without this change, the script can crash, since the empty line will trigger the RuntimeError on line 49.