### PR TITLE
Fix metric output for controllers without Cachevault_Info

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -109,11 +109,12 @@ def handle_megaraid_controller(response):
     add_metric('ports', baselabel, response['HwCfg']['Backend Port Count'])
     add_metric('scheduled_patrol_read', baselabel,
                int('hrs' in response['Scheduled Tasks']['Patrol Read Reoccurrence']))
-    for cvidx, cvinfo in enumerate(response.get('Cachevault_Info', [])):
-        add_metric('cv_temperature',
-                   baselabel + ',cvidx="' + str(cvidx) + '"',
-                   int(cvinfo['Temp'].replace('C', ''))
-                   )
+    if 'Cachevault_Info' in response:
+        for cvidx, cvinfo in enumerate(response.get('Cachevault_Info', [])):
+            add_metric('cv_temperature',
+                       baselabel + ',cvidx="' + str(cvidx) + '"',
+                       int(cvinfo['Temp'].replace('C', ''))
+                       )
 
     time_difference_seconds = -1
     system_time = datetime.strptime(response['Basics'].get('Current System Date/time'),


### PR DESCRIPTION
Since PR #62 seems dead at this point, fix #39 with a cleaner commit history.

The issue comes from controllers without a Cachevault_Info key in their JSON output.