### PR TITLE
Move add_metric into if. Fix #77

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -75,7 +75,7 @@ def handle_common_controller(response):
         response['HwCfg']['ROC temperature(Degree Celsius)'] = response['HwCfg'].pop(
             'ROC temperature(Degree Celc' + 'ius)'
         )
-    add_metric('temperature', baselabel, int(response['HwCfg']['ROC temperature(Degree Celsius)']))
+        add_metric('temperature', baselabel, int(response['HwCfg']['ROC temperature(Degree Celsius)']))
 
 
 def handle_sas_controller(response):


### PR DESCRIPTION
Move add_metric into if to fix #77 only displaying megaraid_controller_info as suggested by frenkye.


Signed-off-by: Roland Wahl <rwahl@protonmail.com>