### PR TITLE
smartmon.sh: allow collecting of additional attributes

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -23,7 +23,7 @@ SMARTCTLAWK
 )"
 
 smartmon_attrs="$(
-  cat <<'SMARTMONATTRS'
+  cat <<SMARTMONATTRS
 airflow_temperature_cel
 command_timeout
 current_pending_sector
@@ -66,8 +66,9 @@ workld_host_reads_perc
 workld_media_wear_indic
 workload_minutes
 SMARTMONATTRS
+$SMARTMONATTRS
 )"
-smartmon_attrs="$(echo "${smartmon_attrs}" | xargs | tr ' ' '|')"
+smartmon_attrs="$(echo "${smartmon_attrs}" | sort -u | xargs | tr ' ' '|')"
 
 parse_smartctl_attributes() {
   local disk="$1"


### PR DESCRIPTION
Allowing additional smart attributes to be collect by providing an environment variable `SMARTMONATTRS`

For example

```bash
export SMARTMONATTRS="$(cat <<'MOREATTRS'
  multi_zone_error_rate
  percent_lifetime_remain
  power_off_retract_count
  reallocate_nand_blk_cnt
  total_host_sector_write
MOREATTRS
)"

./smartmon.sh
# the output will now include the `percent_lifetime_remain`, `power_off_retract_count`, etc, attributes
```

example output:

```txt
...
# HELP smartmon_power_off_retract_count_raw_value SMART metric power_off_retract_count_raw_value
# TYPE smartmon_power_off_retract_count_raw_value gauge
smartmon_power_off_retract_count_raw_value{disk="/dev/sda",type="sat",smart_id="192"} 9.000000e+00
# HELP smartmon_power_off_retract_count_threshold SMART metric power_off_retract_count_threshold
# TYPE smartmon_power_off_retract_count_threshold gauge
smartmon_power_off_retract_count_threshold{disk="/dev/sda",type="sat",smart_id="192"} 0
# HELP smartmon_power_off_retract_count_value SMART metric power_off_retract_count_value
# TYPE smartmon_power_off_retract_count_value gauge
smartmon_power_off_retract_count_value{disk="/dev/sda",type="sat",smart_id="192"} 100
# HELP smartmon_power_off_retract_count_worst SMART metric power_off_retract_count_worst
# TYPE smartmon_power_off_retract_count_worst gauge
smartmon_power_off_retract_count_worst{disk="/dev/sda",type="sat",smart_id="192"} 100
...
```