### PR TITLE
smartmon.py: fix timestamp in smartctl_run metric

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -326,7 +326,7 @@ def collect_ata_error_count(device):
 
 
 def collect_disks_smart_metrics(wakeup_disks):
-    now = int(datetime.datetime.utcnow().timestamp())
+    now = int(datetime.datetime.now().timestamp())
 
     for device in find_devices():
         yield Metric('smartctl_run', device.base_labels, now)


### PR DESCRIPTION
The function [datetime.utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) returns naive instances which are assumed to use the current locale when converted to timestamps using [datetime.timestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp).
As a result the timezone offset is added twice leading to wrong timestamps.