### PR TITLE
smartmon.sh/smartmon.py: fix serial number collection

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -24,6 +24,7 @@ device_info_map = {
     'Model Family': 'model_family',
     'Device Model': 'device_model',
     'Serial Number': 'serial_number',
+    'Serial number': 'serial_number',
     'Firmware Version': 'firmware_version',
 }
 

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -113,7 +113,7 @@ parse_smartctl_info() {
     case "${info_type}" in
     Model_Family) model_family="${info_value}" ;;
     Device_Model) device_model="${info_value}" ;;
-    Serial_Number) serial_number="${info_value}" ;;
+    Serial_Number|Serial_number) serial_number="${info_value}" ;;
     Firmware_Version) fw_version="${info_value}" ;;
     Vendor) vendor="${info_value}" ;;
     Product) product="${info_value}" ;;


### PR DESCRIPTION
Some versions of smartctl show "Serial number" instead of "Serial Number".  Specifically Ubuntu 20.04.2:

```
# smartctl --version
smartctl 7.1 2019-12-30 r5022 [x86_64-linux-5.4.0-77-generic] (local build)
Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org

smartctl comes with ABSOLUTELY NO WARRANTY. This is free
software, and you are welcome to redistribute it under
the terms of the GNU General Public License; either
version 2, or (at your option) any later version.
See http://www.gnu.org for further details.

smartmontools release 7.1 dated 2019-12-30 at 15:00:11 UTC
smartmontools SVN rev 5022 dated 2019-12-30 at 15:00:49
smartmontools build host: x86_64-pc-linux-gnu
smartmontools build with: C++14, GCC 9.3.0
smartmontools configure arguments: '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--localstatedir=/var' '--disable-silent-rules' '--libdir=${prefix}/lib/x86_64-linux-gnu' '--runstatedir=/run' '--disable-maintainer-mode' '--disable-dependency-tracking' '--build=x86_64-linux-gnu' '--host=x86_64-linux-gnu' '--prefix=/usr' '--sysconfdir=/etc' '--mandir=/usr/share/man' '--with-initscriptdir=no' '--docdir=/usr/share/doc/smartmontools' '--with-attributelog=/var/lib/smartmontools/attrlog.' '--with-drivedbdir=/var/lib/smartmontools/drivedb' '--with-exampledir=/usr/share/doc/smartmontools/examples/' '--with-savestates=/var/lib/smartmontools/smartd.' '--with-smartdplugindir=/etc/smartmontools/smartd_warning.d' '--with-smartdscriptdir=/usr/share/smartmontools' '--with-systemdenvfile=/etc/default/smartmontools' '--with-systemdsystemunitdir=/lib/systemd/system' '--with-libsystemd=auto' '--with-selinux' 'build_alias=x86_64-linux-gnu' 'host_alias=x86_64-linux-gnu' 'CXXFLAGS=-g -O2 -fdebug-prefix-map=/build/smartmontools-ZttrSr/smartmontools-7.1=. -fstack-protector-strong -Wformat -Werror=format-security -fsigned-char -Wall -O2' 'LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2' 'CFLAGS=-g -O2 -fdebug-prefix-map=/build/smartmontools-ZttrSr/smartmontools-7.1=. -fstack-protector-strong -Wformat -Werror=format-security -fsigned-char -Wall -O2'

# smartctl -a /dev/sda | grep Serial
Serial number:        <SNIPPED>
# 
```
