### PR TITLE
Add NVME support to smartmon.py

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -355,7 +355,7 @@ def collect_nvme_metrics(device):
         elif label == 'Power On Hours':
             yield Metric('power_on_hours_total', device.base_labels, value.replace(',', ''))
         elif label == 'Temperature':
-            yield Metric('temperature_celcius', device.base_labels, value.replace(' Celsius', ''))
+            yield Metric('temperature_celsius', device.base_labels, value.replace(' Celsius', ''))
         elif label == 'Unsafe Shutdowns':
             yield Metric('unsafe_shutdowns_total', device.base_labels, value)
         elif label == 'Media and Data Integrity Errors':

--- a/smartmon.py
+++ b/smartmon.py
@@ -408,6 +408,7 @@ def collect_disks_smart_metrics(wakeup_disks):
         if device.type == 'nvme':
             yield from collect_nvme_metrics(device)
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', '--wakeup-disks', dest='wakeup_disks', action='store_true')


### PR DESCRIPTION
TBDC: NVME-Metrics are more like `nvme_metrics.sh` like than `smartmon.py`. 

closes #110
