### PR TITLE
smartmon.sh: Make the script aware of multipath disks.

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -194,7 +194,7 @@ device_disk_list() {
         done
 }
 
-smartctl_version="$(/usr/sbin/smartctl -V | head -n1 | awk '$1 == "smartctl" {print $2}')"
+smartctl_version="$("${smartctl}" -V | head -n1 | awk '$1 == "smartctl" {print $2}')"
 
 echo "smartctl_version{version=\"${smartctl_version}\"} 1" | format_output
 
@@ -210,19 +210,19 @@ for device in ${device_list[@]}; do
   active=1
   echo "smartctl_run{disk=\"${disk}\",type=\"${type}\"}" "$(TZ=UTC date '+%s')"
   # Check if the device is in a low-power mode
-  /usr/sbin/smartctl -n standby -d "${type}" "${disk}" > /dev/null || active=0
+  "${smartctl}" -n standby -d "${type}" "${disk}" > /dev/null || active=0
   echo "device_active{disk=\"${disk}\",type=\"${type}\"}" "${active}"
   # Skip further metrics to prevent the disk from spinning up
   test ${active} -eq 0 && continue
   # Get the SMART information and health
-  /usr/sbin/smartctl -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
+  "${smartctl}" -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
   # Get the SMART attributes
   case ${type} in
-  sat) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
-  sat+megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
-  scsi) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
-  megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
-  nvme*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  sat) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+  sat+megaraid*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+  scsi) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  megaraid*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  nvme*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   *)
       (>&2 echo "disk type is not sat, scsi, nvme or megaraid but ${type}")
     exit

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -68,20 +68,7 @@ workload_minutes
 SMARTMONATTRS
 )"
 smartmon_attrs="$(echo "${smartmon_attrs}" | xargs | tr ' ' '|')"
-
-# We should not hardcode the smartctl binary path,
-# instead for those OS that does not follow the
-# same default installation path, we should add it here.
-os_detect() {
-        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-                smartctl="/usr/sbin/smartctl"
-        elif [[ "$OSTYPE" == "freebsd"* ]]; then
-                smartctl="/usr/local/sbin/smartctl"
-        else
-                smartctl="/usr/sbin/smartctl"
-        fi
-}
-os_detect
+smartctl=$(command -v smartctl)
 
 parse_smartctl_attributes() {
   local disk="$1"
@@ -198,7 +185,7 @@ device_disk_list() {
 
         for device in "${smartctl_device_list[@]}"; do
                 disk="$(echo ${device} | cut -f1 -d '|')"
-                serial="$($smartctl -i $disk | grep Serial | tr -d ' ' | awk -F':' '{print $2}')"
+                serial="$($smartctl -i $disk | tr -d ' ' | awk -F':' '/Serial/ {print $2}')"
 
                 disk_check=$(containsDisk "${serial}" "${device_list[@]}")
                 if [[ ! $disk_check -eq "1" ]]; then

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -181,7 +181,7 @@ containsDisk() {
 
 # Create a list of unique disks
 device_disk_list() {
-	mapfile -t smartctl_device_list < <("$smartctl" --scan-open | awk '/^\/dev/{print $1 "|" $3}')
+        mapfile -t smartctl_device_list < <("$smartctl" --scan-open | awk '/^\/dev/{print $1 "|" $3}')
 
         for device in "${smartctl_device_list[@]}"; do
                 disk="$(echo "${device}" | cut -f1 -d '|')"

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -171,7 +171,7 @@ containsDisk() {
         local device_list_filter=("$@")
 
         for device in "${device_list_filter[@]}"; do
-                device_serial=$(echo $device | cut -f3 -d'|')
+                device_serial=$(echo "$device" | cut -f3 -d'|')
                 if [[ "$serial_to_compare" == "$device_serial" ]]; then
                         echo "1"
                         break
@@ -181,11 +181,11 @@ containsDisk() {
 
 # Create a list of unique disks
 device_disk_list() {
-        smartctl_device_list=($($smartctl --scan-open | awk '/^\/dev/{print $1 "|" $3}'))
+	mapfile -t smartctl_device_list < <("$smartctl" --scan-open | awk '/^\/dev/{print $1 "|" $3}')
 
         for device in "${smartctl_device_list[@]}"; do
-                disk="$(echo ${device} | cut -f1 -d '|')"
-                serial="$($smartctl -i $disk | tr -d ' ' | awk -F':' '/Serial/ {print $2}')"
+                disk="$(echo "${device}" | cut -f1 -d '|')"
+                serial="$($smartctl -i "$disk" | tr -d ' ' | awk -F':' '/Serial/ {print $2}')"
 
                 disk_check=$(containsDisk "${serial}" "${device_list[@]}")
                 if [[ ! $disk_check -eq "1" ]]; then
@@ -204,7 +204,7 @@ fi
 
 # Get an unique list of disks in case they are in multipath
 device_disk_list
-for device in ${device_list[@]}; do
+for device in "${device_list[@]}"; do
   disk="$(echo "${device}" | cut -f1 -d'|')"
   type="$(echo "${device}" | cut -f2 -d'|')"
   active=1

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -87,6 +87,15 @@ parse_smartctl_scsi_attributes() {
   while read -r line; do
     attr_type="$(echo "${line}" | tr '=' ':' | cut -f1 -d: | sed 's/^ \+//g' | tr ' ' '_')"
     attr_value="$(echo "${line}" | tr '=' ':' | cut -f2 -d: | sed 's/^ \+//g')"
+
+    # -x additional scsi attributes
+    case "${line}" in
+      *"Recovered via rewrite in-place"*)
+        attr_type="Recovered_via_rewrite_in_place"
+        ((recovered_via_rewrite_in_place++))
+        ;;
+    esac
+
     case "${attr_type}" in
     number_of_hours_powered_up_) power_on="$(echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
     Current_Drive_Temperature) temp_cel="$(echo "${attr_value}" | cut -f1 -d' ' | awk '{ printf "%e\n", $1 }')" ;;
@@ -94,6 +103,7 @@ parse_smartctl_scsi_attributes() {
     Blocks_received_from_initiator_) lbas_written="$(echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
     Accumulated_start-stop_cycles) power_cycle="$(echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
     Elements_in_grown_defect_list) grown_defects="$(echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
+    Recovered_via_rewrite_in_place) rec_viarewrite_in_place="$(echo '${recovered_via_rewrite_in_place}')" ;;
     esac
   done
   [ -n "$power_on" ] && echo "power_on_hours_raw_value{${labels},smart_id=\"9\"} ${power_on}"
@@ -102,6 +112,7 @@ parse_smartctl_scsi_attributes() {
   [ -n "$lbas_written" ] && echo "total_lbas_written_raw_value{${labels},smart_id=\"242\"} ${lbas_written}"
   [ -n "$power_cycle" ] && echo "power_cycle_count_raw_value{${labels},smart_id=\"12\"} ${power_cycle}"
   [ -n "$grown_defects" ] && echo "grown_defects_count_raw_value{${labels},smart_id=\"12\"} ${grown_defects}"
+  [ -n "$rec_viarewrite_in_place" ] && echo "recovered_via_rewrite_in_place{${labels}} ${recovered_via_rewrite_in_place}"
 }
 
 parse_smartctl_info() {
@@ -220,7 +231,7 @@ for device in "${device_list[@]}"; do
   case ${type} in
   sat) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
   sat+megaraid*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
-  scsi) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  scsi) "${smartctl}" -A -x -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   megaraid*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   nvme*) "${smartctl}" -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   *)


### PR DESCRIPTION
On systems where disks are in multipath, we can have duplicate metrics of the same disk. One way to mitigate this issue is to compare the DISK SERIAL of the devices and create a list of non-duplicated disks. These changes have no impact on systems with no disks in multipath.

**Example:**
**Linux multipath)**
multipath output:
```
35000cca0bb7ca048 dm-12 HGST,HUS728T8TAL4204
size=7.3T features='0' hwhandler='0' wp=rw
`-+- policy='service-time 0' prio=0 status=active
  |- 15:0:4:0   sdk  8:160  active undef running
  `- 15:0:55:0  sdbj 67:208 active undef running
```

Before patch prom output:
```
storage-linux:/tmp# cat old.prom |grep sdk | head -1
smartmon_device_active{disk="/dev/sdk",type="scsi"} 1
storage-linux:/tmp# cat old.prom |grep sdbj | head -1
smartmon_device_active{disk="/dev/sdbj",type="scsi"} 1
```

After patch prom output:
```
storage-linux:/tmp# cat smartmon-new.prom |grep sdk | head -1
smartmon_device_active{disk="/dev/sdk",type="scsi"} 1
storage-linux:/tmp# cat smartmon-new.prom |grep sdbj | head -1
storage:/tmp#
```

**FreeBSD multipath)**
multipath output:
```
Providers:
1. Name: multipath/disk-7804ff03
   Mediasize: 4000787025920 (3.6T)
   Sectorsize: 4096
   Mode: r1w1e1
   State: OPTIMAL
Consumers:
1. Name: da8
   Mediasize: 4000787030016 (3.6T)
   Sectorsize: 4096
   Mode: r2w2e2
   State: ACTIVE
2. Name: da50
   Mediasize: 4000787030016 (3.6T)
   Sectorsize: 4096
   Mode: r2w2e2
   State: PASSIVE
```
Before patch prom output:
```
storage-freebsd:/tmp# cat old.prom |grep da8 | head -1
smartmon_device_active{disk="/dev/da8",type="scsi"} 1
storage-freebsd:/tmp# cat old.prom |grep da50 | head -1
smartmon_device_active{disk="/dev/da50",type="scsi"} 1
```

After patch prom output:
```
storage-freebsd:/tmp# cat smartmon.prom | grep da8 | head -1
smartmon_device_active{disk="/dev/da8",type="scsi"} 1
storage-freebsd:/tmp# cat smartmon.prom | grep da50 | head -1
storage-freebsd:/tmp#
```

And while I'm here, don't hardcode the smartctl binary path, some OS like FreeBSD installs it in a different path.