### PR TITLE
Cachevault support for storcli.py collector

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Reporting a security issue
+
+The Prometheus security policy, including how to report vulnerabilities, can be
+found here:
+
+https://prometheus.io/docs/operating/security/

--- a/btrfs_stats.py
+++ b/btrfs_stats.py
@@ -40,7 +40,7 @@ def get_btrfs_errors(mountpoint):
     if p.returncode != 0:
         raise RuntimeError("btrfs returned exit code %d" % p.returncode)
     for line in stdout.splitlines():
-        if line == '':
+        if not line:
             continue
         # Sample line:
         # [/dev/vdb1].flush_io_errs   0

--- a/chrony.py
+++ b/chrony.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Description: Gather metrics from Chrony NTP.
+#
+
+import subprocess
+import sys
+
+from prometheus_client import CollectorRegistry, Gauge, generate_latest
+
+
+def chronyc(*args, check=True):
+    """Chrony client wrapper
+
+    Returns:
+       (str) Data piped to stdout by the chrony subprocess.
+    """
+    return subprocess.run(
+        ['chronyc', *args], stdout=subprocess.PIPE, check=check
+    ).stdout.decode('utf-8')
+
+
+def chronyc_tracking():
+    return chronyc('-c', 'tracking').split(',')
+
+
+def main():
+    registry = CollectorRegistry()
+    chrony_tracking = chronyc_tracking()
+
+    if len(chrony_tracking) != 14:
+        print("ERROR: Unable to parse chronyc tracking CSV", file=sys.stderr)
+        sys.exit(1)
+
+    g = Gauge('chrony_tracking_reference_info',
+              'The stratum of the current preferred source',
+              ['ref_id', 'ref_host'],
+              registry=registry)
+    g.labels(chrony_tracking[0], chrony_tracking[1]).set(1)
+
+    g = Gauge('chrony_tracking_stratum',
+              'The stratum of the current preferred source',
+              registry=registry)
+    g.set(chrony_tracking[2])
+
+    g = Gauge('chrony_tracking_system_offset_seconds',
+              'The current estimated drift of system time from true time',
+              registry=registry)
+    g.set(chrony_tracking[4])
+
+    g = Gauge('chrony_tracking_last_offset_seconds',
+              'The estimated local offset on the last clock update.',
+              registry=registry)
+    g.set(chrony_tracking[5])
+
+    g = Gauge('chrony_tracking_root_dispersion_seconds',
+              'The absolute bound on the computer’s clock accuracy',
+              registry=registry)
+    g.set(chrony_tracking[5])
+
+    print(generate_latest(registry).decode("utf-8"), end='')
+
+
+if __name__ == "__main__":
+    main()

--- a/node_os_info.sh
+++ b/node_os_info.sh
@@ -1,0 +1,58 @@
+#!/bin/sh -e
+
+# Generate node_os_info and node_os_version metrics on legacy systems
+# which are not handled by node_exporter's own collector
+# (e.g. CentOS 6)
+
+[ -f /etc/os-release ] && exit 0
+[ -f /usr/lib/os-release ] && exit 0
+
+ID=""
+ID_LIKE=""
+NAME=""
+PRETTY_NAME=""
+VERSION=""
+VERSION_CODENAME=""
+VERSION_ID=""
+VERSION_METRIC=""
+
+if [ -f /etc/redhat-release ]; then
+  # CentOS release 6.10 (Final)
+  PRETTY_NAME="$(cat /etc/redhat-release)"
+  if [ -f /etc/centos-release ]; then
+    ID="centos"
+  elif [ -f /etc/oracle-release ]; then
+    ID="ol"
+  fi
+  ID_LIKE="rhel fedora"
+  NAME="$(expr "$PRETTY_NAME" : '\([^ ]*\)')" || true
+  VERSION="$(expr "$PRETTY_NAME" : '.* \([0-9].*\)')" || true
+  VERSION_ID="$(expr "$PRETTY_NAME" : '.* \([0-9][0-9.]*\)')" || true
+  # metric cannot distinguish 6.1 from 6.10, so only keep the integer part
+  VERSION_METRIC="$(expr "$VERSION_ID" : '\([0-9]*\)')" || true
+elif [ -f /etc/lsb-release ]; then
+  # DISTRIB_ID=Ubuntu
+  # DISTRIB_RELEASE=12.04
+  # DISTRIB_CODENAME=precise
+  # DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"
+  # Beware, old versions of CentOS with package "redhat-lsb-core" look like this instead:
+  # LSB_VERSION=base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch
+
+  # shellcheck disable=SC1091
+  . /etc/lsb-release
+  ID="$(echo "${DISTRIB_ID}" | tr '[:upper:]' '[:lower:]')"
+  NAME="${DISTRIB_ID}"
+  PRETTY_NAME="${DISTRIB_DESCRIPTION}"
+  VERSION="${DISTRIB_RELEASE} (${DISTRIB_CODENAME})"
+  VERSION_CODENAME="${DISTRIB_CODENAME}"
+  VERSION_ID="${DISTRIB_RELEASE}"
+  # 12.04.1 -> 12.04
+  VERSION_METRIC="$(expr "$VERSION_ID" : '\([0-9]*\|[0-9]*\.[0-9]*\)')" || true
+fi
+
+[ "$VERSION_METRIC" = "" ] && VERSION_METRIC="0"
+
+cat <<EOS
+node_os_info{id="$ID",id_like="$ID_LIKE",name="$NAME",pretty_name="$PRETTY_NAME",version="$VERSION",version_codename="$VERSION_CODENAME",version_id="$VERSION_ID"} 1
+node_os_version{id="$ID",id_like="$ID_LIKE",name="$NAME"} $VERSION_METRIC
+EOS

--- a/storcli.py
+++ b/storcli.py
@@ -114,6 +114,12 @@ def handle_megaraid_controller(response):
                    baselabel + ',cvidx="' + str(cvidx) + '"',
                    int(cvinfo['Temp'].replace('C', ''))
                    )
+        add_metric('cv_optimal', baselabel + ',cvidx="' + str(cvidx) + '"',
+                int(cvinfo['State'] == 'Optimal'))
+        add_metric('cv_degraded',baselabel + ',cvidx="' + str(cvidx) + '"',
+                int(cvinfo['State'] == 'Degraded'))
+        add_metric('cv_failed', baselabel + ',cvidx="' + str(cvidx) + '"',
+                int(cvinfo['State'] == 'Failed'))
 
     time_difference_seconds = -1
     system_time = datetime.strptime(response['Basics'].get('Current System Date/time'),

--- a/storcli.py
+++ b/storcli.py
@@ -102,7 +102,7 @@ def handle_megaraid_controller(response):
 
     # BBU Status Optimal value is 0 for cachevault and 32 for BBU
     add_metric('battery_backup_healthy', baselabel,
-               int(response['Status']['BBU Status'] in [0, 32]))
+               int(response['Status']['BBU Status'] in [0, 32, 'NA']))
     add_metric('degraded', baselabel, int(response['Status']['Controller Status'] == 'Degraded'))
     add_metric('failed', baselabel, int(response['Status']['Controller Status'] == 'Failed'))
     add_metric('healthy', baselabel, int(response['Status']['Controller Status'] == 'Optimal'))

--- a/storcli.py
+++ b/storcli.py
@@ -109,7 +109,7 @@ def handle_megaraid_controller(response):
     add_metric('ports', baselabel, response['HwCfg']['Backend Port Count'])
     add_metric('scheduled_patrol_read', baselabel,
                int('hrs' in response['Scheduled Tasks']['Patrol Read Reoccurrence']))
-    for cvidx, cvinfo in enumerate(response['Cachevault_Info']):
+    for cvidx, cvinfo in enumerate(response.get('Cachevault_Info', [])):
         add_metric('cv_temperature',
                    baselabel + ',cvidx="' + str(cvidx) + '"',
                    int(cvinfo['Temp'].replace('C', ''))

--- a/storcli.py
+++ b/storcli.py
@@ -115,11 +115,11 @@ def handle_megaraid_controller(response):
                    int(cvinfo['Temp'].replace('C', ''))
                    )
         add_metric('cv_optimal', baselabel + ',cvidx="' + str(cvidx) + '"',
-                int(cvinfo['State'] == 'Optimal'))
-        add_metric('cv_degraded',baselabel + ',cvidx="' + str(cvidx) + '"',
-                int(cvinfo['State'] == 'Degraded'))
+                   int(cvinfo['State'] == 'Optimal'))
+        add_metric('cv_degraded', baselabel + ',cvidx="' + str(cvidx) + '"',
+                   int(cvinfo['State'] == 'Degraded'))
         add_metric('cv_failed', baselabel + ',cvidx="' + str(cvidx) + '"',
-                int(cvinfo['State'] == 'Failed'))
+                   int(cvinfo['State'] == 'Failed'))
 
     time_difference_seconds = -1
     system_time = datetime.strptime(response['Basics'].get('Current System Date/time'),


### PR DESCRIPTION
Patches that allows the collector to report `battery_backup_healthy` when the BBU is absent (because there is a Cachevault supercap instead), as well as expose metrics for the Cachevault health directly.

Tested on two different servers, one which has an actual Cachevault failure