### PR TITLE
Fix incorrect smartctl mode for scsi drives

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -188,7 +188,7 @@ for device in ${device_list}; do
   case ${type} in
   sat) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
   sat+megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
-  scsi) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  scsi) /usr/sbin/smartctl -a -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   megaraid*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   nvme*) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
   *)


### PR DESCRIPTION
smartctl -A makes sense for sata drives since it gets the block of numbered attributes parse_smartctl_attributes expects.  For scsi drives -A gives too little information and even excludes half of the fields parse_smartctl_scsi_attributes explicitly is trying to pull out.  Passing lowercase -a fixes this

Signed-off-by: GunArm <james.barrett.lewis@gmail.com>