### PR TITLE
nvme_metrics.sh: use 'jq -r' for 128-bit "string" numbers

### DIFF
--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -68,30 +68,30 @@ for device in ${device_list}; do
   value_critical_warning="$(echo "$json_check" | jq '.critical_warning')"
   echo "critical_warning_total{device=\"${disk}\"} ${value_critical_warning}"
 
-  value_media_errors="$(echo "$json_check" | jq '.media_errors')"
+  value_media_errors="$(echo "$json_check" | jq -r '.media_errors')"
   echo "media_errors_total{device=\"${disk}\"} ${value_media_errors}"
 
-  value_num_err_log_entries="$(echo "$json_check" | jq '.num_err_log_entries')"
+  value_num_err_log_entries="$(echo "$json_check" | jq -r '.num_err_log_entries')"
   echo "num_err_log_entries_total{device=\"${disk}\"} ${value_num_err_log_entries}"
 
-  value_power_cycles="$(echo "$json_check" | jq '.power_cycles')"
+  value_power_cycles="$(echo "$json_check" | jq -r '.power_cycles')"
   echo "power_cycles_total{device=\"${disk}\"} ${value_power_cycles}"
 
-  value_power_on_hours="$(echo "$json_check" | jq '.power_on_hours')"
+  value_power_on_hours="$(echo "$json_check" | jq -r '.power_on_hours')"
   echo "power_on_hours_total{device=\"${disk}\"} ${value_power_on_hours}"
 
-  value_controller_busy_time="$(echo "$json_check" | jq '.controller_busy_time')"
+  value_controller_busy_time="$(echo "$json_check" | jq -r '.controller_busy_time')"
   echo "controller_busy_time_seconds{device=\"${disk}\"} ${value_controller_busy_time}"
 
-  value_data_units_written="$(echo "$json_check" | jq '.data_units_written')"
+  value_data_units_written="$(echo "$json_check" | jq -r '.data_units_written')"
   echo "data_units_written_total{device=\"${disk}\"} ${value_data_units_written}"
 
-  value_data_units_read="$(echo "$json_check" | jq '.data_units_read')"
+  value_data_units_read="$(echo "$json_check" | jq -r '.data_units_read')"
   echo "data_units_read_total{device=\"${disk}\"} ${value_data_units_read}"
 
-  value_host_read_commands="$(echo "$json_check" | jq '.host_read_commands')"
+  value_host_read_commands="$(echo "$json_check" | jq -r '.host_read_commands')"
   echo "host_read_commands_total{device=\"${disk}\"} ${value_host_read_commands}"
 
-  value_host_write_commands="$(echo "$json_check" | jq '.host_write_commands')"
+  value_host_write_commands="$(echo "$json_check" | jq -r '.host_write_commands')"
   echo "host_write_commands_total{device=\"${disk}\"} ${value_host_write_commands}"
 done | format_output


### PR DESCRIPTION
nvme-cli v2.x and later outputs various NVMe 128-bit counters as double-quoted strings, which tripped up this script and resulted in Prometheus text metrics exposition format violations.

This change is also backwards-compatible with the previous nvme-cli v1.x.

Fixes: #130