### PR TITLE
nvme_metrics.sh: ensure consistent & predictable numeric format

### DIFF
--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -9,6 +9,9 @@ set -eu
 #
 # Author: Henk <henk@wearespindle.com>
 
+# Ensure predictable numeric / date formats, etc.
+export LC_ALL=C
+
 # Check if we are root
 if [ "$EUID" -ne 0 ]; then
   echo "${0##*/}: Please run as root!" >&2


### PR DESCRIPTION
nvme-cli 2.3 and later appears to output numeric values in localized style (even in JSON output), e.g. using comma as thousands separator.

Similar to smartmon.sh, set LC_ALL=C to ensure the least fancy output.

Signed-off-by: Daniel Swarbrick <daniel.swarbrick@gmail.com>

cc: @anarcat 