### PR TITLE
lvm-prom-collector: add metadata to the thin metrics

### DIFF
--- a/lvm-prom-collector
+++ b/lvm-prom-collector
@@ -9,7 +9,7 @@
 # -g for used and free space of logical volume groups
 # -p for used and free space of physical volumes.
 # -s for the percentage usage of the snapshots
-# -t for the percentage usage of the thin pools and their metadata
+# -t for the percentage usage of the thin pools
 #
 # * * * * *   root lvm-prom-collector -g | sponge /var/lib/prometheus/node-exporter/lvm.prom
 #
@@ -28,7 +28,7 @@ display_usage() {
   echo "Use -g for used and free space of logical volume groups."
   echo "use -p for used and free space of physical volumes."
   echo "Use -s for the percentage usage of the snapshots."
-  echo "Use -t for the percentage usage of the thin pools and their metadata."
+  echo "Use -t for the percentage usage of the thin pools."
 }
 
 if [ "$(id -u)" != "0" ]; then
@@ -105,20 +105,28 @@ if [ "$snapshots" = true ] ; then
 fi
 
 if [ "$thin_pools" = true ] ; then
-  echo "# HELP node_lvm_thin_pools_allocated percentage of allocated thin pool data"
-  echo "# TYPE node_lvm_thin_pools_allocated gauge"
-  echo "# HELP node_lvm_thin_pools_metadata percentage of allocated thin pool metadata"
-  echo "# TYPE node_lvm_thin_pools_metadata gauge"
 
   lvs_output=$(lvs --noheadings --select 'lv_attr=~[^t.*]' --units b --nosuffix --unquoted --nameprefixes --options lv_uuid,vg_name,data_percent,metadata_percent 2>/dev/null)
+
+  echo "# HELP node_lvm_thin_pools_allocated percentage of allocated thin pool data"
+  echo "# TYPE node_lvm_thin_pools_allocated gauge"
   echo "$lvs_output" | while IFS= read -r line ; do
     # Skip if the line is empty
     [ -z "$line" ] && continue
     declare $line
     # Convert ',' to '.'
     data_percent=$(echo "$LVM2_DATA_PERCENT" | sed 's/\,/./' )
-    metadata_percent=$(echo "$LVM2_METADATA_PERCENT" | sed 's/\,/./' )
     echo "node_lvm_thin_pools_allocated{uuid=\"$LVM2_LV_UUID\", vgroup=\"$LVM2_VG_NAME\"} $data_percent"
+  done
+
+  echo "# HELP node_lvm_thin_pools_metadata percentage of allocated thin pool metadata"
+  echo "# TYPE node_lvm_thin_pools_metadata gauge"
+  echo "$lvs_output" | while IFS= read -r line ; do
+    # Skip if the line is empty
+    [ -z "$line" ] && continue
+    declare $line
+    # Convert ',' to '.'
+    metadata_percent=$(echo "$LVM2_METADATA_PERCENT" | sed 's/\,/./' )
     echo "node_lvm_thin_pools_metadata{uuid=\"$LVM2_LV_UUID\", vgroup=\"$LVM2_VG_NAME\"} $metadata_percent"
   done
 fi

--- a/lvm-prom-collector
+++ b/lvm-prom-collector
@@ -9,7 +9,7 @@
 # -g for used and free space of logical volume groups
 # -p for used and free space of physical volumes.
 # -s for the percentage usage of the snapshots
-# -t for the percentage usage of the thin pools
+# -t for the percentage usage of the thin pools and their metadata
 #
 # * * * * *   root lvm-prom-collector -g | sponge /var/lib/prometheus/node-exporter/lvm.prom
 #
@@ -28,7 +28,7 @@ display_usage() {
   echo "Use -g for used and free space of logical volume groups."
   echo "use -p for used and free space of physical volumes."
   echo "Use -s for the percentage usage of the snapshots."
-  echo "Use -t for the percentage usage of the thin pools."
+  echo "Use -t for the percentage usage of the thin pools and their metadata."
 }
 
 if [ "$(id -u)" != "0" ]; then
@@ -107,15 +107,19 @@ fi
 if [ "$thin_pools" = true ] ; then
   echo "# HELP node_lvm_thin_pools_allocated percentage of allocated thin pool data"
   echo "# TYPE node_lvm_thin_pools_allocated gauge"
+  echo "# HELP node_lvm_thin_pools_metadata percentage of allocated thin pool metadata"
+  echo "# TYPE node_lvm_thin_pools_metadata gauge"
 
-  lvs_output=$(lvs --noheadings --select 'lv_attr=~[^t.*]' --units b --nosuffix --unquoted --nameprefixes --options lv_uuid,vg_name,data_percent 2>/dev/null)
+  lvs_output=$(lvs --noheadings --select 'lv_attr=~[^t.*]' --units b --nosuffix --unquoted --nameprefixes --options lv_uuid,vg_name,data_percent,metadata_percent 2>/dev/null)
   echo "$lvs_output" | while IFS= read -r line ; do
     # Skip if the line is empty
     [ -z "$line" ] && continue
     declare $line
     # Convert ',' to '.'
     data_percent=$(echo "$LVM2_DATA_PERCENT" | sed 's/\,/./' )
+    metadata_percent=$(echo "$LVM2_METADATA_PERCENT" | sed 's/\,/./' )
     echo "node_lvm_thin_pools_allocated{uuid=\"$LVM2_LV_UUID\", vgroup=\"$LVM2_VG_NAME\"} $data_percent"
+    echo "node_lvm_thin_pools_metadata{uuid=\"$LVM2_LV_UUID\", vgroup=\"$LVM2_VG_NAME\"} $metadata_percent"
   done
 fi
 


### PR DESCRIPTION
Hi, 

i added the metadata usage for each lvm thin as i found this info crucial for monitoring. 

Here is a sample output : 

```
# HELP node_physical_volume_size Physical volume size in bytes
# TYPE node_physical_volume_size gauge
# HELP node_physical_volume_free Physical volume free space in bytes
# TYPE node_physical_volume_free gauge
node_physical_volume_size{name="/dev/md0", uuid="2msKv6-3JnJ-ihKo-w6i5-M1Tj-sddN-yFtFOL", format="lvm2"} 500036534272
node_physical_volume_free{name="/dev/md0", uuid="2msKv6-3JnJ-ihKo-w6i5-M1Tj-sddN-yFtFOL", format="lvm2"} 8518631424
# HELP node_lvm_snapshots_allocated percentage of allocated data to a snapshot
# TYPE node_lvm_snapshots_allocated gauge
# HELP node_lvm_thin_pools_allocated percentage of allocated thin pool data
# TYPE node_lvm_thin_pools_allocated gauge
# HELP node_lvm_thin_pools_metadata percentage of allocated thin pool metadata
# TYPE node_lvm_thin_pools_metadata gauge
node_lvm_thin_pools_allocated{uuid="t2gKmH-8K4K-nwpE-G3CB-DjQS-sjFp-YY7G3L", vgroup="pve"} 52.34
node_lvm_thin_pools_metadata{uuid="t2gKmH-8K4K-nwpE-G3CB-DjQS-sjFp-YY7G3L", vgroup="pve"} 6.09
# HELP node_volume_group_size Volume group size in bytes
# TYPE node_volume_group_size gauge
# HELP node_volume_group_free volume group free space in bytes
# TYPE node_volume_group_free gauge
node_volume_group_size{name="pve"} 500036534272
node_volume_group_free{name="pve"} 8518631424
```