### PR TITLE
Add new Python-based nvme_metrics collector

### DIFF
--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -41,12 +41,12 @@ metrics = {
     ),
     "data_units_read": Counter(
         "data_units_read_total",
-        "Device data units read",
+        "Number of 512-byte data units read by host, reported in thousands",
         ["device"], namespace=namespace, registry=registry,
     ),
     "data_units_written": Counter(
         "data_units_written_total",
-        "Device data units written",
+        "Number of 512-byte data units written by host, reported in thousands",
         ["device"], namespace=namespace, registry=registry,
     ),
     "device_info": Gauge(

--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -202,6 +202,17 @@ def main():
 
 
 if __name__ == "__main__":
+    if os.geteuid() != 0:
+        print("ERROR: script requires root privileges", file=sys.stderr)
+        sys.exit(1)
+
+    # Check if nvme-cli is installed
+    try:
+        exec_nvme()
+    except FileNotFoundError:
+        print("ERROR: nvme-cli is not installed. Aborting.", file=sys.stderr)
+        sys.exit(1)
+
     try:
         main()
     except Exception as e:

--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+"""
+NVMe device metrics textfile collector.
+Requires nvme-cli package.
+
+Formatted with Black:
+$ black -l 100 nvme_metrics.py
+"""
+
+import json
+import os
+import re
+import sys
+import subprocess
+
+# Disable automatic addition of _created series. Must be set before importing prometheus_client.
+os.environ["PROMETHEUS_DISABLE_CREATED_SERIES"] = "true"
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest  # noqa: E402
+
+registry = CollectorRegistry()
+namespace = "nvme"
+
+metrics = {
+    # fmt: off
+    "avail_spare": Gauge(
+        "available_spare_ratio",
+        "Device available spare ratio",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "controller_busy_time": Counter(
+        "controller_busy_time_seconds",
+        "Device controller busy time in seconds",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "critical_warning": Gauge(
+        "critical_warning",
+        "Device critical warning bitmap field",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "data_units_read": Counter(
+        "data_units_read_total",
+        "Device data units read",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "data_units_written": Counter(
+        "data_units_written_total",
+        "Device data units written",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "device_info": Gauge(
+        "device_info",
+        "Device information",
+        ["device", "model", "firmware", "serial"], namespace=namespace, registry=registry,
+    ),
+    "host_read_commands": Counter(
+        "host_read_commands_total",
+        "Device read commands from host",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "host_write_commands": Counter(
+        "host_write_commands_total",
+        "Device write commands from host",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "media_errors": Counter(
+        "media_errors_total",
+        "Device media errors total",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "num_err_log_entries": Counter(
+        "num_err_log_entries_total",
+        "Device error log entry count",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "nvmecli": Gauge(
+        "nvmecli",
+        "nvme-cli tool information",
+        ["version"], namespace=namespace, registry=registry,
+    ),
+    "percent_used": Gauge(
+        "percentage_used_ratio",
+        "Device percentage used ratio",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "physical_size": Gauge(
+        "physical_size_bytes",
+        "Device size in bytes",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "power_cycles": Counter(
+        "power_cycles_total",
+        "Device number of power cycles",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "power_on_hours": Counter(
+        "power_on_hours_total",
+        "Device power-on hours",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "sector_size": Gauge(
+        "sector_size_bytes",
+        "Device sector size in bytes",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "spare_thresh": Gauge(
+        "available_spare_threshold_ratio",
+        "Device available spare threshold ratio",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "temperature": Gauge(
+        "temperature_celsius",
+        "Device temperature in degrees Celsius",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "unsafe_shutdowns": Counter(
+        "unsafe_shutdowns_total",
+        "Device number of unsafe shutdowns",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    "used_bytes": Gauge(
+        "used_bytes",
+        "Device used size in bytes",
+        ["device"], namespace=namespace, registry=registry,
+    ),
+    # fmt: on
+}
+
+
+def exec_nvme(*args):
+    """
+    Execute nvme CLI tool with specified arguments and return captured stdout result. Set LC_ALL=C
+    in child process environment so that the nvme tool does not perform any locale-specific number
+    or date formatting, etc.
+    """
+    cmd = ["nvme", *args]
+    return subprocess.check_output(cmd, stderr=subprocess.PIPE, env=dict(os.environ, LC_ALL="C"))
+
+
+def exec_nvme_json(*args):
+    """
+    Execute nvme CLI tool with specified arguments and return parsed JSON output.
+    """
+    output = exec_nvme(*args, "--output-format", "json")
+    return json.loads(output)
+
+
+def main():
+    match = re.match(r"^nvme version (\S+)", exec_nvme("version").decode())
+    if match:
+        cli_version = match.group(1)
+    else:
+        cli_version = "unknown"
+    metrics["nvmecli"].labels(cli_version).set(1)
+
+    device_list = exec_nvme_json("list")
+
+    for device in device_list["Devices"]:
+        device_path = device["DevicePath"]
+
+        metrics["device_info"].labels(
+            device_path,
+            device["ModelNumber"],
+            device["Firmware"],
+            device["SerialNumber"].strip(),
+        ).set(1)
+
+        metrics["sector_size"].labels(device_path).set(device["SectorSize"])
+        metrics["physical_size"].labels(device_path).set(device["PhysicalSize"])
+        metrics["used_bytes"].labels(device_path).set(device["UsedBytes"])
+
+        smart_log = exec_nvme_json("smart-log", device_path)
+
+        # Various counters in the NVMe specification are 128-bit, which would have to discard
+        # resolution if converted to a JSON number (i.e., float64_t). Instead, nvme-cli marshals
+        # them as strings. As such, they need to be explicitly cast to int or float when using them
+        # in Counter metrics.
+        metrics["data_units_read"].labels(device_path).inc(int(smart_log["data_units_read"]))
+        metrics["data_units_written"].labels(device_path).inc(int(smart_log["data_units_written"]))
+        metrics["host_read_commands"].labels(device_path).inc(int(smart_log["host_read_commands"]))
+        metrics["host_write_commands"].labels(device_path).inc(
+            int(smart_log["host_write_commands"])
+        )
+        metrics["avail_spare"].labels(device_path).set(smart_log["avail_spare"] / 100)
+        metrics["spare_thresh"].labels(device_path).set(smart_log["spare_thresh"] / 100)
+        metrics["percent_used"].labels(device_path).set(smart_log["percent_used"] / 100)
+        metrics["critical_warning"].labels(device_path).set(smart_log["critical_warning"])
+        metrics["media_errors"].labels(device_path).inc(int(smart_log["media_errors"]))
+        metrics["num_err_log_entries"].labels(device_path).inc(
+            int(smart_log["num_err_log_entries"])
+        )
+        metrics["power_cycles"].labels(device_path).inc(int(smart_log["power_cycles"]))
+        metrics["power_on_hours"].labels(device_path).inc(int(smart_log["power_on_hours"]))
+        metrics["controller_busy_time"].labels(device_path).inc(
+            int(smart_log["controller_busy_time"])
+        )
+        metrics["unsafe_shutdowns"].labels(device_path).inc(int(smart_log["unsafe_shutdowns"]))
+
+        # NVMe reports temperature in kelvins; convert it to degrees Celsius.
+        metrics["temperature"].labels(device_path).set(smart_log["temperature"] - 273)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print("ERROR: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+
+    print(generate_latest(registry).decode(), end="")


### PR DESCRIPTION
This is a Python reimplementation of the existing nvme_metrics.sh script. It features several new metrics:
- nvme_device_info (model, firmware, serial number)
- nvme_physical_size_bytes
- nvme_used_bytes
- nvme_sector_size_bytes
- nvme_unsafe_shutdowns_total

It retains backwards compatibility with the metric names of nvme_metrics.sh with one exception:
The original nvme_critical_warning_total metric is incorrect, because the source is not a counter. The NVMe critical warning field, defined in section 5.16.1.3 of the NVMe Base Specification 2.0c, is a bitmap, and thus should be a gauge in Prometheus. As such, the metric is renamed to simply nvme_critical_warning.

It is my intention that this script should (eventually) supersede and replace the existing `nvme_metrics.sh` script.