### PR TITLE
Create instant_per_process_cpu_mem_usage.sh

### DIFF
--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Get CPU & Mem metrics, lightweight implementation
+# Written (quickly) in 2023 by NetInvent
+# SCRIPT_VERSION 2023060201
+
+
+# -w [n] forces total column width to [n] so data won't be truncated
+# -c forces full commandline, which we need in order to get command arguments
+# -bn 1 makes top run once in batch mode
+
+top -w 120 -cbn 1 | awk '{
+        # Skip headers
+        if (NR<8) { next };
+        # Get all command arguments
+        args=""; for(i = 13; i<= NF; i++) if ($i!="") {args=args" "$i};
+        # Sanitize argumetns
+        gsub("{|}|\"", "", args);
+        # Dont keep more than 30 chars for args, since we limited top -w size, we wont need this
+        #args=substr(args, 1, 30);
+        # Remove self process
+        if ($12=="top" && args=" -w 120 -cbn 1") { next };
+        # Do not keep not cpu hungry entries
+        if ($9!="0.0") {
+                if (cputype==0) { printf "# TYPE top_process_cpu_usage gauge\n# HELP top_process_cpu_usage ps gathered instant CPU usage per process\n"; cputype=1 };
+                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$12"\",sanitized_args=\""args"\"} " $9z"\n"};
+        # Do not keep not memory hungry entries
+        if ($10!="0.0") {
+                if (memtype==0) { printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage ps gathered memory usage per process\n"; memtype=1 };
+                printf "top_process_memory_usage{pid=\""$1"\",process=\""$12"\",sanitized_args=\""args"\"} " $10z"\n"};
+}'

--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -2,7 +2,7 @@
 
 # Get CPU & Mem metrics, lightweight implementation
 # Written (quickly) in 2023 by NetInvent
-# SCRIPT_VERSION 2023060201
+# SCRIPT_VERSION 2023110201
 
 
 # -w [n] forces total column width to [n] so data won't be truncated
@@ -14,8 +14,11 @@ top -w 120 -cbn 1 | awk '{
         if (NR<8) { next };
         # Get all command arguments
         args=""; for(i = 13; i<= NF; i++) if ($i!="") {args=args" "$i};
-        # Sanitize argumetns
+        # Sanitize arguments
         gsub("{|}|\"", "", args);
+        # Sanitize debian style floats in top
+        gsub(",", ".", $9);
+        gsub(",", ".", $10);
         # Dont keep more than 30 chars for args, since we limited top -w size, we wont need this
         #args=substr(args, 1, 30);
         # Remove self process

--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -15,7 +15,7 @@ top -w 120 -cbn 1 | awk '{
         # Get all command arguments
         args=""; for(i = 13; i<= NF; i++) if ($i!="") {args=args" "$i};
         # Sanitize arguments
-        gsub("{|}|\"", "", args);
+        gsub("{|}|\\\\|\"", "", args);
         # Sanitize debian style floats in top
         gsub(",", ".", $9);
         gsub(",", ".", $10);

--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -4,15 +4,33 @@
 # Written (quickly) in 2023 by NetInvent
 # SCRIPT_VERSION 2026052701
 
+# ps works multiple times faster than top, and shows more processes
 # top represents roughly 95% of the time spent by this script
 # awk doesn't need optimisations here
+
+printf "# TYPE top_process_cpu_usage gauge\n# HELP top_process_cpu_usage ps gathered instant CPU usage per process\n"
+printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage ps gathered memory usage per process\n"
+
+if [ "$1" == "" ]; then
+
+ps -ax -o pid,%cpu,%mem,comm,args --cols 80 | awk '{
+        args=""; for(i = 5; i<= NF; i++) if ($i!="") {args=args" "$i};
+        gsub("{|}|\\\\|\"", "", args);
+        # Remove self process
+        if ($4=="ps" && args=" -ax -o pid,%cpu,%mem,comm,args --cols 80") { next };
+        # Do not keep not cpu hungry entries
+        if ($2!="0.0") {
+                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$4"\",args=\""args"\"} " $2z"\n"};
+        # Do not keep not memory hungry entries
+        if ($3!="0.0") {
+                printf "top_process_memory_usage{pid=\""$1"\",process=\""$4"\",args=\""args"\"} " $3z"\n"};
+}'
+
+elif [ "$1" == "top" ]; then
 
 # -w [n] forces total column width to [n] so data won't be truncated
 # -c forces full commandline, which we need in order to get command arguments
 # -bn 1 makes top run once in batch mode
-
-printf "# TYPE top_process_cpu_usage gauge\n# HELP top_process_cpu_usage ps gathered instant CPU usage per process\n"
-printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage ps gathered memory usage per process\n"
 
 top -w 120 -cbn 1 | awk '{
         # Skip headers
@@ -35,3 +53,5 @@ top -w 120 -cbn 1 | awk '{
         if ($10!="0.0") {
                 printf "top_process_memory_usage{pid=\""$1"\",process=\""$12"\",args=\""args"\"} " $10z"\n"};
 }'
+
+fi

--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -13,17 +13,17 @@ printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage p
 
 if [ "$1" == "" ]; then
 
-ps -ax -o pid,%cpu,%mem,comm,args --cols 80 | awk '{
-        args=""; for(i = 5; i<= NF; i++) if ($i!="") {args=args" "$i};
+ps -ax -o %cpu,%mem,comm,args --cols 80 | awk '{
+        args=""; for(i = 4; i<= NF; i++) if ($i!="") {args=args" "$i};
         gsub("{|}|\\\\|\"", "", args);
         # Remove self process
-        if ($4=="ps" && args=" -ax -o pid,%cpu,%mem,comm,args --cols 80") { next };
+        if ($3=="ps" && args=" -ax -o %cpu,%mem,comm,args --cols 80") { next };
         # Do not keep not cpu hungry entries
-        if ($2!="0.0") {
-                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$4"\",args=\""args"\"} " $2z"\n"};
+        if ($1!="0.0") {
+                printf "top_process_cpu_usage{process=\""$3"\",args=\""args"\"} " $1z"\n"};
         # Do not keep not memory hungry entries
-        if ($3!="0.0") {
-                printf "top_process_memory_usage{pid=\""$1"\",process=\""$4"\",args=\""args"\"} " $3z"\n"};
+        if ($2!="0.0") {
+                printf "top_process_memory_usage{process=\""$3"\",args=\""args"\"} " $2z"\n"};
 }'
 
 elif [ "$1" == "top" ]; then
@@ -48,10 +48,10 @@ top -w 120 -cbn 1 | awk '{
         if ($12=="top" && args=" -w 120 -cbn 1") { next };
         # Do not keep not cpu hungry entries
         if ($9!="0.0") {
-                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$12"\",args=\""args"\"} " $9z"\n"};
+                printf "top_process_cpu_usage{process=\""$12"\",args=\""args"\"} " $9z"\n"};
         # Do not keep not memory hungry entries
         if ($10!="0.0") {
-                printf "top_process_memory_usage{pid=\""$1"\",process=\""$12"\",args=\""args"\"} " $10z"\n"};
+                printf "top_process_memory_usage{process=\""$12"\",args=\""args"\"} " $10z"\n"};
 }'
 
 fi

--- a/instant_per_process_cpu_mem_usage.sh
+++ b/instant_per_process_cpu_mem_usage.sh
@@ -2,17 +2,22 @@
 
 # Get CPU & Mem metrics, lightweight implementation
 # Written (quickly) in 2023 by NetInvent
-# SCRIPT_VERSION 2023110201
+# SCRIPT_VERSION 2026052701
 
+# top represents roughly 95% of the time spent by this script
+# awk doesn't need optimisations here
 
 # -w [n] forces total column width to [n] so data won't be truncated
 # -c forces full commandline, which we need in order to get command arguments
 # -bn 1 makes top run once in batch mode
 
+printf "# TYPE top_process_cpu_usage gauge\n# HELP top_process_cpu_usage ps gathered instant CPU usage per process\n"
+printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage ps gathered memory usage per process\n"
+
 top -w 120 -cbn 1 | awk '{
         # Skip headers
         if (NR<8) { next };
-        # Get all command arguments
+        # Get all command arguments and sanitize them, avoid making empty string if no arguments found
         args=""; for(i = 13; i<= NF; i++) if ($i!="") {args=args" "$i};
         # Sanitize arguments
         gsub("{|}|\\\\|\"", "", args);
@@ -25,10 +30,8 @@ top -w 120 -cbn 1 | awk '{
         if ($12=="top" && args=" -w 120 -cbn 1") { next };
         # Do not keep not cpu hungry entries
         if ($9!="0.0") {
-                if (cputype==0) { printf "# TYPE top_process_cpu_usage gauge\n# HELP top_process_cpu_usage ps gathered instant CPU usage per process\n"; cputype=1 };
-                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$12"\",sanitized_args=\""args"\"} " $9z"\n"};
+                printf "top_process_cpu_usage{pid=\""$1"\",process=\""$12"\",args=\""args"\"} " $9z"\n"};
         # Do not keep not memory hungry entries
         if ($10!="0.0") {
-                if (memtype==0) { printf "# TYPE top_process_memory_usage gauge\n# HELP top_process_memory_usage ps gathered memory usage per process\n"; memtype=1 };
-                printf "top_process_memory_usage{pid=\""$1"\",process=\""$12"\",sanitized_args=\""args"\"} " $10z"\n"};
+                printf "top_process_memory_usage{pid=\""$1"\",process=\""$12"\",args=\""args"\"} " $10z"\n"};
 }'


### PR DESCRIPTION
Hello,

I've built this (very tiny footprint) script that allows to get non named per process CPU metrics.
Most other tools out there require to setup process group names in order to catch process metrics, other solutions provide with non instant cpu metrics given by `ps`.

Getting instant per process cpu usage is really useful for admins to quickly find a culprit.

I did understand that you discourage shell scripts in favor of the Python client, but this one is mostly a big oneliner, and would only get a less tiny footprint if being rewritten in Python.

Would you mind merging this one ?
I've found no other solution out there to achieve the same, so I normally did not reinvent the wheel ;)

I can also provide the corresponding Grafana dashboard of course:
![image](https://github.com/prometheus-community/node-exporter-textfile-collector-scripts/assets/4681318/7c5d96c9-005b-4361-aac1-2f94efa089c8)

Hope this will help any other admins ;)
Best regards.
