### PR TITLE
lvm: add support for "all" checks

### DIFF
--- a/lvm-prom-collector
+++ b/lvm-prom-collector
@@ -48,8 +48,14 @@ snapshots=false
 physical=false
 groups=false
 
-while getopts "htpsg" opt; do
+while getopts "ahtpsg" opt; do
   case $opt in
+    a)
+      thin_pools=true
+      snapshots=true
+      physical=true
+      groups=true
+      ;;
     p)
       physical=true
       ;;


### PR DESCRIPTION
It seems rather inconvenient to have to specify all those switches by hand. Right now, I need to specify `-gpst` to get all the stats and, if some new metric get added (e.g. #159 hopefully), I need to remember to update my callers to match. This is annoying.

Let's make a `-a` that's going to do it all for us. Hell, i'd make it the default, personally, if I wasn't worried about breaking people's stuff...

This obviously conflicts with other PRs that might add another flag like this, like #159. Please prioritize the latter.