### PR TITLE
add "4096" as healthy BBU code

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -249,7 +249,7 @@ def handle_megaraid_controller(response):
     if response["Status"]["BBU Status"] != "NA":
         # BBU Status Optimal value is 0 for normal, 8 for charging.
         metrics["bbu_healthy"].labels(controller_index).set(
-            response["Status"]["BBU Status"] in [0, 8]
+            response["Status"]["BBU Status"] in [0, 8, 4096]
         )
 
     metrics["ctrl_degraded"].labels(controller_index).set(


### PR DESCRIPTION
Old PERC controllers (at least PERC H730/740 Mini) with FW 4.270.00-8168 return BBU status 4096. Comparing the output with MegaCLI output it seems that this bit corresponds to "Learning cycle required" indicator. However since controller runs learning cycles by itself there is no reason for alerting.