### PR TITLE
Add the node_reboot_required metric to yum.sh

### DIFF
--- a/yum.sh
+++ b/yum.sh
@@ -3,7 +3,7 @@
 # Description: Expose metrics from yum updates.
 #
 # Author: Slawomir Gonet <slawek@otwiera.cz>
-# 
+#
 # Based on apt.sh by Ben Kochie <superq@gmail.com>
 
 set -u -o pipefail
@@ -36,4 +36,15 @@ if [[ -n "${upgrades}" ]] ; then
   echo "${upgrades}"
 else
   echo 'yum_upgrades_pending{origin=""} 0'
+fi
+
+# If yum-utils/dnf-utils is not installed then we skip rendering this metric
+if [[ -x /bin/needs-restarting ]] ; then
+  echo '# HELP node_reboot_required Node reboot is required for software updates.'
+  echo '# TYPE node_reboot_required gauge'
+  if /bin/needs-restarting -r  > /dev/null 2>&1 ; then
+    echo 'node_reboot_required 0'
+  else
+    echo 'node_reboot_required 1'
+  fi
 fi


### PR DESCRIPTION
Added the node_reboot_required metric to yum.sh, based on PR #70, with the requested changes incorporated in the code

---

Since PR #70 has been stale for more than 2 years I took the liberty to rewrite it with the changes requested incorporated.
Let me now if this is ok or it needs more work.