### PR TITLE
Remove available/spare/user percentage calculation

### DIFF
--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -183,9 +183,9 @@ def main():
         metrics["host_write_commands"].labels(device_name).inc(
             int(smart_log["host_write_commands"])
         )
-        metrics["avail_spare"].labels(device_name).set(smart_log["avail_spare"] / 100)
-        metrics["spare_thresh"].labels(device_name).set(smart_log["spare_thresh"] / 100)
-        metrics["percent_used"].labels(device_name).set(smart_log["percent_used"] / 100)
+        metrics["avail_spare"].labels(device_name).set(smart_log["avail_spare"])
+        metrics["spare_thresh"].labels(device_name).set(smart_log["spare_thresh"])
+        metrics["percent_used"].labels(device_name).set(smart_log["percent_used"])
         metrics["critical_warning"].labels(device_name).set(smart_log["critical_warning"])
         metrics["media_errors"].labels(device_name).inc(int(smart_log["media_errors"]))
         metrics["num_err_log_entries"].labels(device_name).inc(

--- a/nvme_metrics.sh
+++ b/nvme_metrics.sh
@@ -60,13 +60,13 @@ for device in ${device_list}; do
   value_temperature="$(echo "$json_check" | jq '.temperature - 273')"
   echo "temperature_celsius{device=\"${disk}\"} ${value_temperature}"
 
-  value_available_spare="$(echo "$json_check" | jq '.avail_spare / 100')"
+  value_available_spare="$(echo "$json_check" | jq '.avail_spare')"
   echo "available_spare_ratio{device=\"${disk}\"} ${value_available_spare}"
 
-  value_available_spare_threshold="$(echo "$json_check" | jq '.spare_thresh / 100')"
+  value_available_spare_threshold="$(echo "$json_check" | jq '.spare_thresh')"
   echo "available_spare_threshold_ratio{device=\"${disk}\"} ${value_available_spare_threshold}"
 
-  value_percentage_used="$(echo "$json_check" | jq '.percent_used / 100')"
+  value_percentage_used="$(echo "$json_check" | jq '.percent_used')"
   echo "percentage_used_ratio{device=\"${disk}\"} ${value_percentage_used}"
 
   value_critical_warning="$(echo "$json_check" | jq '.critical_warning')"


### PR DESCRIPTION
This PR removes incorrect calculations for some NVMe related metrics.

According to the [NVM Express Base Specification](https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-2.0c-2022.10.04-Ratified.pdf) the fields `Available Spare`, `Available Spare Threshold` and `Percentage Used` return normalized percentage values.

So the dividing the value by `100` is not necessary and returns incorrect percentage values.