### PR TITLE
smartmon.py: completely remove unused smartmon_run metric

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -80,13 +80,6 @@ metrics = {
         namespace=namespace,
         registry=registry,
     ),
-    "smartctl_run": Gauge(
-        "smartctl_run",
-        "SMART metric smartctl_run",
-        ["device", "disk"],
-        namespace=namespace,
-        registry=registry,
-    ),
     "device_active": Gauge(
         "device_active",
         "SMART metric device_active",


### PR DESCRIPTION
The metric has mostly been removed in #152. This change also cleans the stale metric instance.