### PR TITLE
Support host prefix for apt_info.py

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -111,7 +111,7 @@ def _write_cache_timestamps(registry):
 def _write_reboot_required(registry):
     g = Gauge('node_reboot_required', "Node reboot is required for software updates.",
               registry=registry)
-    g.set(int(os.path.isfile(os.path.join(hostPrefix,'/run/reboot-required'))))
+    g.set(int(os.path.isfile(os.path.join(hostPrefix,'run/reboot-required'))))
 
 
 def _main():


### PR DESCRIPTION
This will allow us to run apt_info.py on the host from the container.

```
docker run --rm -it --entrypoint bash -v "/:/hostfs" ubuntu:22.04 -c 'apt update && apt install -y python3-prometheus-client python3-apt curl && curl https://raw.githubusercontent.com/prometheus-community/node-exporter-textfile-collector-scripts/7aaf51790bf19911ebcaa49f6474b26bd04b3910/apt_info.py -o /tmp/apt_info.py && APT_HOSTPREFIX=/hostfs/ python3 /tmp/apt_info.py'
```