### PR TITLE
Some disks doesnt report device speed correctly, crashing script execution

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -353,9 +353,15 @@ def create_metrics_of_physical_drive(physical_drive, detailed_info_array, contro
         metrics["pd_link_speed"].labels(controller_index, enclosure, slot).set(
             attributes["Link Speed"].split(".")[0]
         )
-        metrics["pd_device_speed"].labels(controller_index, enclosure, slot).set(
-            attributes["Device Speed"].split(".")[0]
-        )
+        # Some disks doesnt report device speed correctly
+        # when pd_device_speed metric assigns a string value: "Unknown"
+        # script execution crashes in that case assign a 0 speed value.
+        if attributes["Device Speed"].split(".")[0] == "Unknown":
+            metrics["pd_device_speed"].labels(controller_index, enclosure, slot).set('0')
+        else:
+            metrics["pd_device_speed"].labels(controller_index, enclosure, slot).set(
+                attributes["Device Speed"].split(".")[0]
+            )
         metrics["pd_commissioned_spare"].labels(controller_index, enclosure, slot).set(
             settings["Commissioned Spare"] == "Yes"
         )


### PR DESCRIPTION
Some disks doesnt report device speed correctly when pd_device_speed metric assigns a string value: "Unknown" script execution crashes in that case assign a 0 speed value.