### PR TITLE
do not run apt update or simulate apt dist-upgrade

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -3,6 +3,18 @@
 # Description: Expose metrics from apt. This is inspired by and
 # intended to be a replacement for the original apt.sh.
 #
+# This script deliberately does *not* update the apt cache. You need
+# something else to run `apt update` regularly for the metrics to be
+# up to date. This can be done in numerous ways, but the canonical way
+# is to use the normal `APT::Periodic::Update-Package-Lists`
+# setting.
+#
+# This, for example, will enable a nightly job that runs `apt update`:
+#
+#     echo 'APT::Periodic::Update-Package-Lists "1";' > /etc/apt/apt.conf.d/99_auto_apt_update.conf
+#
+# See /usr/lib/apt/apt.systemd.daily for details.
+#
 # Dependencies: python3-apt, python3-prometheus-client
 #
 # Authors: Kyle Fazzari <kyrofa@ubuntu.com>
@@ -10,7 +22,6 @@
 
 import apt
 import collections
-import contextlib
 import os
 from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
@@ -82,15 +93,6 @@ def _write_reboot_required(registry):
 
 def _main():
     cache = apt.cache.Cache()
-
-    # First of all, attempt to update the index. If we don't have permission
-    # to do so (or it fails for some reason), it's not the end of the world,
-    # we'll operate on the old index.
-    with contextlib.suppress(apt.cache.LockFailedException, apt.cache.FetchFailedException):
-        cache.update()
-
-    cache.open()
-    cache.upgrade(True)
 
     registry = CollectorRegistry()
     _write_pending_upgrades(registry, cache)


### PR DESCRIPTION
This is causing all sorts of problems. The first of which is that we're hitting our poor mirrors every time the script is ran, which, in the Debian package configuration, is *every 15 minutes* (!!).

The second is that this locks the cache and makes this script needlessly stumble upon a possible regression in APT from Debian bookworm and Ubuntu 22.06:

https://bugs.launchpad.net/ubuntu/+source/apt/+bug/2003851

That still has to be confirmed: it's possible that `apt update` can hang for a long time, but that shouldn't concern us if we delegate this work out of band.

I also do not believe actually performing the `dist-upgrade` calculations is necessary to compute the pending upgrades at all. I've done work with python-apt for other projects and haven't found that to be required: the cache has the necessary information about pending upgrades.

Closes: #179