### PR TITLE
report the apt cache timestamp

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -74,6 +74,14 @@ def _write_autoremove_pending(registry, cache):
     g.set(len(autoremovable_packages))
 
 
+def _write_cache_timestamps(registry):
+    g = Gauge('apt_package_cache_timestamp_seconds', "Apt update last run time.", registry=registry)
+    try:
+        g.set(os.stat('/var/cache/apt/pkgcache.bin').st_mtime)
+    except OSError:
+        pass
+
+
 def _write_reboot_required(registry):
     g = Gauge('node_reboot_required', "Node reboot is required for software updates.",
               registry=registry)
@@ -96,6 +104,7 @@ def _main():
     _write_pending_upgrades(registry, cache)
     _write_held_upgrades(registry, cache)
     _write_autoremove_pending(registry, cache)
+    _write_cache_timestamps(registry)
     _write_reboot_required(registry)
     print(generate_latest(registry).decode(), end='')
 


### PR DESCRIPTION
We use the `pkgcache.bin` modification time as a heuristic, but there might be a better way to do this.

We also silently ignore errors when pulling that file to avoid broken systems from breaking the other metrics. I believe this will lead to a null metric which is probably what we want anyway.

A possible improvement to this would be to individually inspect the `InRelease` files and report the mirror's timestamps as well, but that's more involved. It's also not a priority compared to this fix, because we want the update timestamp if we remove the `apt update` run (in #181).

Closes: #180