### PR TITLE
storcli.py: Skip battery backup unit status if it does not exist

### DIFF
--- a/storcli.py
+++ b/storcli.py
@@ -251,7 +251,7 @@ def handle_sas_controller(response):
 def handle_megaraid_controller(response):
     controller_index = response["Basics"]["Controller"]
 
-    if response["Status"]["BBU Status"] != "NA":
+    if "BBU Status" in response["Status"] and response["Status"]["BBU Status"] != "NA":
         # BBU Status Optimal value is 0 for normal, 8 for charging.
         metrics["bbu_healthy"].labels(controller_index).set(
             response["Status"]["BBU Status"] in [0, 8, 4096]


### PR DESCRIPTION
Some HPE RAID controllers have an external battery (Energy pack aka HPE Smart Storage Battery) instead of a controller onboard battery backup unit. With our controller (HPE MR416i-a Gen10+) the "BBU Status" field is not present in the storcli output and storcli.py aborts data collection.

This commit skips the BBU Status field if it does not exist.

Closes #190.