### PR TITLE
Add needrestart_info.py to monitore needrestart.

### DIFF
--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -145,10 +145,17 @@ def write_sessions(registry, needrestart_data):
 def main():
     registry = CollectorRegistry()
 
-    needrestart_output = subprocess.run(
-        ["needrestart", "-b"], capture_output=True, text=True
-    ).stdout
-    needrestart_data = NeedRestartData(needrestart_output)
+    try:
+        needrestart_output = subprocess.run(
+            ["needrestart", "-b"], capture_output=True, text=True, check=True
+        ).stdout
+        needrestart_data = NeedRestartData(needrestart_output)
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing needrestart:\n{e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred:\n{e}")
+        sys.exit(1)
 
     write_timestamp(registry, needrestart_data)
     write_kernel(registry, needrestart_data)

--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -33,7 +33,7 @@ class KernelStatus(Enum):
 class MicroCodeStatus(Enum):
     UNKNOWN = 0
     CURRENT = 1
-    OBSELETE = 2
+    OBSOLETE = 2
 
 
 class NeedRestartData:

--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -11,6 +11,7 @@ Dependencies: python >= 3.5, python3-prometheus-client, needrestart
 Authors: RomainMou
 """
 
+import sys
 import time
 import subprocess
 from collections import Counter

--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+#
+#
+# Description: Expose metrics from needrestart.
+#
+# This script runs needrestart in batch mode. It will never ask for input
+# and will never restart or upgrade anything.
+#
+# Dependencies: python >= 3.5, python3-prometheus-client, needrestart
+#
+# Authors: RomainMou
+
+import time
+import subprocess
+from collections import Counter
+from enum import Enum
+from prometheus_client import (
+    CollectorRegistry,
+    Gauge,
+    generate_latest,
+)
+
+
+class KernelStatus(Enum):
+    UNKNOWN = 0
+    CURRENT = 1
+    ABI_UPGRADE = 2
+    VERSION_UPGRADE = 3
+
+
+class MicroCodeStatus(Enum):
+    UNKNOWN = 0
+    CURRENT = 1
+    OBSELETE = 2
+
+
+class NeedrestartParser:
+    def __init__(self, needrestart_output):
+        # Some default value
+        self.timestamp = int(time.time())
+        self.version = None
+        self.kernel_status = None
+        self.microcode_status = None
+        self.kernel_current_version = ""
+        self.kernel_expected_version = ""
+        self.microcode_current_version = ""
+        self.microcode_expected_version = ""
+        needrestart_counter = Counter()
+
+        # Parse the cmd output
+        for line in needrestart_output.stdout.decode().splitlines():
+            key, value = line.split(": ")
+            if key == "NEEDRESTART-VER":
+                self.version = value
+            # Kernel informations
+            elif key == "NEEDRESTART-KCUR":
+                self.kernel_current_version = value
+            elif key == "NEEDRESTART-KEXP":
+                self.kernel_expected_version = value
+            elif key == "NEEDRESTART-KSTA":
+                self.kernel_status = KernelStatus(int(value))
+            # Microcode informations
+            elif key == "NEEDRESTART-UCCUR":
+                self.microcode_current_version = value
+            elif key == "NEEDRESTART-UCEXP":
+                self.microcode_expected_version = value
+            elif key == "NEEDRESTART-UCSTA":
+                self.microcode_status = MicroCodeStatus(int(value))
+            # Count the others
+            else:
+                needrestart_counter.update({key})
+
+        self.services_count = needrestart_counter["NEEDRESTART-SVC"]
+        self.containers_count = needrestart_counter["NEEDRESTART-CONT"]
+        self.sessions_count = needrestart_counter["NEEDRESTART-SESS"]
+
+
+def _write_timestamp(registry, needrestart_data):
+    g = Gauge(
+        "needrestart_timestamp",
+        "information about the version and when it was last run",
+        labelnames=["version"],
+        registry=registry,
+    )
+    g.labels(needrestart_data.version).set(needrestart_data.timestamp)
+
+
+def _write_kernel(registry, needrestart_data):
+    if needrestart_data.kernel_status:
+        e = Gauge(
+            "needrestart_kernel_status",
+            "information about the kernel status",
+            labelnames=["current", "expected"],
+            registry=registry,
+        )
+        e.labels(
+            needrestart_data.kernel_current_version,
+            needrestart_data.kernel_expected_version,
+        ).set(needrestart_data.kernel_status.value)
+
+
+def _write_microcode(registry, needrestart_data):
+    if needrestart_data.microcode_status:
+        e = Gauge(
+            "needrestart_microcode_status",
+            "information about the microcode status",
+            labelnames=["current", "expected"],
+            registry=registry,
+        )
+        e.labels(
+            needrestart_data.microcode_current_version,
+            needrestart_data.microcode_expected_version,
+        ).set(needrestart_data.microcode_status.value)
+
+
+def _write_services(registry, needrestart_data):
+    g = Gauge(
+        "needrestart_services_count",
+        "number of services requiring a restart",
+        registry=registry,
+    )
+    g.set(needrestart_data.services_count)
+
+
+def _write_containers(registry, needrestart_data):
+    g = Gauge(
+        "needrestart_containers_count",
+        "number of containers requiring a restart",
+        registry=registry,
+    )
+    g.set(needrestart_data.containers_count)
+
+
+def _write_sessions(registry, needrestart_data):
+    g = Gauge(
+        "needrestart_sessions_count",
+        "number of sessions requiring a restart",
+        registry=registry,
+    )
+    g.set(needrestart_data.sessions_count)
+
+
+def _main():
+    registry = CollectorRegistry()
+    needrestart_data = NeedrestartParser(
+        subprocess.run(["needrestart", "-b"], stdout=subprocess.PIPE)
+    )
+
+    _write_timestamp(registry, needrestart_data)
+    _write_kernel(registry, needrestart_data)
+    _write_microcode(registry, needrestart_data)
+    _write_services(registry, needrestart_data)
+    _write_containers(registry, needrestart_data)
+    _write_sessions(registry, needrestart_data)
+
+    print(generate_latest(registry).decode(), end="")
+
+
+if __name__ == "__main__":
+    _main()

--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -152,10 +152,10 @@ def main():
         ).stdout
         needrestart_data = NeedRestartData(needrestart_output)
     except subprocess.CalledProcessError as e:
-        print(f"Error executing needrestart:\n{e}")
+        print(f"Error executing needrestart:\n{e}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:
-        print(f"An unexpected error occurred:\n{e}")
+        print(f"An unexpected error occurred:\n{e}", file=sys.stderr)
         sys.exit(1)
 
     write_timestamp(registry, needrestart_data)

--- a/needrestart_info.py
+++ b/needrestart_info.py
@@ -79,7 +79,7 @@ class NeedRestartData:
 
 def write_timestamp(registry, needrestart_data):
     g = Gauge(
-        "needrestart_timestamp",
+        "needrestart_timestamp_seconds",
         "information about the version and when it was last run",
         labelnames=["version"],
         registry=registry,
@@ -90,7 +90,7 @@ def write_timestamp(registry, needrestart_data):
 def write_kernel(registry, needrestart_data):
     if needrestart_data.kernel_status:
         e = Gauge(
-            "needrestart_kernel_status",
+            "needrestart_kernel_status_info",
             "information about the kernel status",
             labelnames=["current", "expected"],
             registry=registry,
@@ -104,7 +104,7 @@ def write_kernel(registry, needrestart_data):
 def write_microcode(registry, needrestart_data):
     if needrestart_data.microcode_status:
         e = Gauge(
-            "needrestart_microcode_status",
+            "needrestart_microcode_status_info",
             "information about the microcode status",
             labelnames=["current", "expected"],
             registry=registry,
@@ -117,7 +117,7 @@ def write_microcode(registry, needrestart_data):
 
 def write_services(registry, needrestart_data):
     g = Gauge(
-        "needrestart_services_count",
+        "needrestart_services_total",
         "number of services requiring a restart",
         registry=registry,
     )
@@ -126,7 +126,7 @@ def write_services(registry, needrestart_data):
 
 def write_containers(registry, needrestart_data):
     g = Gauge(
-        "needrestart_containers_count",
+        "needrestart_containers_total",
         "number of containers requiring a restart",
         registry=registry,
     )
@@ -135,7 +135,7 @@ def write_containers(registry, needrestart_data):
 
 def write_sessions(registry, needrestart_data):
     g = Gauge(
-        "needrestart_sessions_count",
+        "needrestart_sessions_total",
         "number of sessions requiring a restart",
         registry=registry,
     )


### PR DESCRIPTION
Hi,

I've made a small script to retrieve some metrics from `needrestart`, and perhaps it could be useful for others?

The script runs `needrestart -b` (batch mode), parses the output, and displays some metrics. It looks like this:
```
# HELP needrestart_timestamp information about the version and when it was last run
# TYPE needrestart_timestamp gauge
needrestart_timestamp{version="3.5"} 1.702655157e+09
# HELP needrestart_kernel_status information about the kernel status
# TYPE needrestart_kernel_status gauge
needrestart_kernel_status{current="5.10.0-26-amd64",expected="5.10.0-26-amd64"} 1.0
# HELP needrestart_services_count number of services requiring a restart
# TYPE needrestart_services_count gauge
needrestart_services_count 0.0
# HELP needrestart_containers_count number of containers requiring a restart
# TYPE needrestart_containers_count gauge
needrestart_containers_count 0.0
# HELP needrestart_sessions_count number of sessions requiring a restart
# TYPE needrestart_sessions_count gauge
needrestart_sessions_count 0.0
```