### PR TITLE
apt_info.py: fix apt_upgrades_pending and apt_upgrades_held

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -70,7 +70,7 @@ def _write_pending_upgrades(registry, cache):
 
 def _write_held_upgrades(registry, cache):
     held_candidates = {
-        p.candidate for p in cache 
+        p.candidate for p in cache
         if p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)

--- a/apt_info.py
+++ b/apt_info.py
@@ -70,7 +70,8 @@ def _write_pending_upgrades(registry, cache):
 
 def _write_held_upgrades(registry, cache):
     held_candidates = {
-        p.candidate for p in cache if p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
+        p.candidate for p in cache 
+        if p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 

--- a/apt_info.py
+++ b/apt_info.py
@@ -57,7 +57,7 @@ def _write_pending_upgrades(registry, cache):
     # only one upgrade, not two). See the following issue for more details:
     # https://github.com/prometheus-community/node-exporter-textfile-collector-scripts/issues/85
     candidates = {
-        p.candidate for p in cache.get_changes() if p.is_installed and p.marked_upgrade
+        p.candidate for p in cache if p.is_installed and p.is_upgradable
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
@@ -69,7 +69,9 @@ def _write_pending_upgrades(registry, cache):
 
 
 def _write_held_upgrades(registry, cache):
-    held_candidates = {p.candidate for p in cache if p.is_upgradable and p.marked_keep}
+    held_candidates = {
+        p.candidate for p in cache if p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
+    }
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 
     if upgrade_list:

--- a/apt_info.py
+++ b/apt_info.py
@@ -52,12 +52,8 @@ def _convert_candidates_to_upgrade_infos(candidates):
 
 
 def _write_pending_upgrades(registry, cache):
-    # Discount any changes that apply to packages that aren't installed (e.g.
-    # count an upgrade to package A that adds a new dependency on package B as
-    # only one upgrade, not two). See the following issue for more details:
-    # https://github.com/prometheus-community/node-exporter-textfile-collector-scripts/issues/85
     candidates = {
-        p.candidate for p in cache if p.is_installed and p.is_upgradable
+        p.candidate for p in cache if p.is_upgradable
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 


### PR DESCRIPTION
Fixes #193 

Fixed `apt_upgrades_pending` always empty, as after #181, `cache.upgrade(True)` is no longer called in script. This call marks the packages that could be upgraded, and without it, no package has the marked_upgrade boolean set to true. Changed to filter all packages that are installed and upgradable. This should match the output of `apt list --upgradable`

Also fixed apt_upgrades_held including all upgradable packages including packages that are not actually held. Package can be detected to be held according to https://askubuntu.com/a/965543.