### PR TITLE
btrfs_stats.py: Precompiled regular expressions improve performance

### DIFF
--- a/btrfs_stats.py
+++ b/btrfs_stats.py
@@ -14,6 +14,7 @@ from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
 DEVICE_PATTERN = re.compile(r"^\[([^\]]+)\]\.(\S+)\s+(\d+)$", re.MULTILINE)
 
+
 def get_btrfs_mount_points():
     """List all btrfs mount points.
 

--- a/btrfs_stats.py
+++ b/btrfs_stats.py
@@ -12,6 +12,8 @@ import subprocess
 from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
 
+DEVICE_PATTERN = re.compile(r"^\[([^\]]+)\]\.(\S+)\s+(\d+)$", re.MULTILINE)
+
 def get_btrfs_mount_points():
     """List all btrfs mount points.
 
@@ -47,7 +49,7 @@ def get_btrfs_errors(mountpoint):
             continue
         # Sample line:
         # [/dev/vdb1].flush_io_errs   0
-        m = re.search(r"^\[([^\]]+)\]\.(\S+)\s+(\d+)$", line.decode("utf-8"))
+        m = DEVICE_PATTERN.match(line.decode("utf-8"))
         if not m:
             raise RuntimeError("unexpected output from btrfs: '%s'" % line)
         yield m.group(1), m.group(2), int(m.group(3))

--- a/btrfs_stats.py
+++ b/btrfs_stats.py
@@ -12,7 +12,7 @@ import subprocess
 from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
 
-DEVICE_PATTERN = re.compile(r"^\[([^\]]+)\]\.(\S+)\s+(\d+)$", re.MULTILINE)
+DEVICE_PATTERN = re.compile(r"^\[([^\]]+)\]\.(\S+)\s+(\d+)$")
 
 
 def get_btrfs_mount_points():


### PR DESCRIPTION
**Performance Improvement:** The regular expression `DEVICE_PATTERN` is precompiled and stored as a function-level variable, ensuring it doesn't need to be recompiled for each iteration in the loop