### PR TITLE
Create script to expose cronjob status

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python3
-#
-# Description: Expose metrics from apt. This is inspired by and
-# intended to be a replacement for the original apt.sh.
-#
-# This script deliberately does *not* update the apt cache. You need
-# something else to run `apt update` regularly for the metrics to be
-# up to date. This can be done in numerous ways, but the canonical way
-# is to use the normal `APT::Periodic::Update-Package-Lists`
-# setting.
-#
-# This, for example, will enable a nightly job that runs `apt update`:
-#
-#     echo 'APT::Periodic::Update-Package-Lists "1";' > /etc/apt/apt.conf.d/99_auto_apt_update.conf
-#
-# See /usr/lib/apt/apt.systemd.daily for details.
-#
-# Dependencies: python3-apt, python3-prometheus-client
-#
-# Authors: Kyle Fazzari <kyrofa@ubuntu.com>
-#          Daniel Swarbrick <dswarbrick@debian.org>
+
+"""
+Description: Expose metrics from apt. This is inspired by and
+intended to be a replacement for the original apt.sh.
+
+This script deliberately does *not* update the apt cache. You need
+something else to run `apt update` regularly for the metrics to be
+up to date. This can be done in numerous ways, but the canonical way
+is to use the normal `APT::Periodic::Update-Package-Lists`
+setting.
+
+This, for example, will enable a nightly job that runs `apt update`:
+
+    echo 'APT::Periodic::Update-Package-Lists "1";' > /etc/apt/apt.conf.d/99_auto_apt_update.conf
+
+See /usr/lib/apt/apt.systemd.daily for details.
+
+Dependencies: python3-apt, python3-prometheus-client
+
+Authors: Kyle Fazzari <kyrofa@ubuntu.com>
+         Daniel Swarbrick <dswarbrick@debian.org>
+"""
 
 import apt
 import apt_pkg

--- a/apt_info.py
+++ b/apt_info.py
@@ -90,13 +90,16 @@ def _write_autoremove_pending(registry, cache):
 def _write_cache_timestamps(registry):
     g = Gauge('apt_package_cache_timestamp_seconds', "Apt update last run time.", registry=registry)
     apt_pkg.init_config()
-    if apt_pkg.config.find_b("APT::Periodic::Update-Package-Lists"):
+    if (
+        apt_pkg.config.find_b("APT::Periodic::Update-Package-Lists") and
+        os.path.isfile("/var/lib/apt/periodic/update-success-stamp")
+    ):
         # if we run updates automatically with APT::Periodic, we can
-        # check this timestamp file
+        # check this timestamp file if it exists
         stamp_file = "/var/lib/apt/periodic/update-success-stamp"
     else:
-        # if not, let's just fallback on the lists directory
-        stamp_file = '/var/lib/apt/lists'
+        # if not, let's just fallback on the partial file of the lists directory
+        stamp_file = '/var/lib/apt/lists/partial'
     try:
         g.set(os.stat(stamp_file).st_mtime)
     except OSError:

--- a/directory-size.sh
+++ b/directory-size.sh
@@ -13,4 +13,4 @@
 echo "# HELP node_directory_size_bytes Disk space used by some directories"
 echo "# TYPE node_directory_size_bytes gauge"
 du --block-size=1 --summarize "$@" \
-  | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_directory_size_bytes{directory="\2"} \1/p'
+  | awk '{ print "node_directory_size_bytes{directory=\"" $2 "\"} "  $1 }'

--- a/yum.sh
+++ b/yum.sh
@@ -32,17 +32,17 @@ upgrades=$(check_upgrades)
 
 echo '# HELP yum_upgrades_pending Yum package pending updates by origin.'
 echo '# TYPE yum_upgrades_pending gauge'
-if [[ -n "${upgrades}" ]] ; then
+if [[ -n "${upgrades}" ]]; then
   echo "${upgrades}"
 else
   echo 'yum_upgrades_pending{origin=""} 0'
 fi
 
 # If yum-utils/dnf-utils is not installed then we skip rendering this metric
-if [[ -x /bin/needs-restarting ]] ; then
+if [[ -x /bin/needs-restarting ]]; then
   echo '# HELP node_reboot_required Node reboot is required for software updates.'
   echo '# TYPE node_reboot_required gauge'
-  if /bin/needs-restarting -r  > /dev/null 2>&1 ; then
+  if /bin/needs-restarting -r >/dev/null 2>&1; then
     echo 'node_reboot_required 0'
   else
     echo 'node_reboot_required 1'


### PR DESCRIPTION
This script exposes the exit status of cronjobs. This script was born out of a desire to monitor and alert on cronjobs using Prometheus and Alertmanager. 

This script was inspired by https://janikvonrotz.ch/2020/09/07/monitor-cron-jobs-with-prometheus-grafana-and-node-exporter/

As far as I'm aware there isn't another facility for exposing metrics related to this in Node Exporter.

This script receives two arguments, the description of the cronjob as a string and the exit status of the previous command. It prints the metric to stdout.

Usage:

```bash
<command> ; cronjob "<description>" $?
```

Example crontab entry:

```
* * * * * echo "Hello world!"; cronjob "greeting" $? | sponge /var/lib/prometheus/node-exporter/cronjob_greeting.prom
```

Example textfile:

```
[vagrant@rocky8 ~]$ cat /var/lib/prometheus/node-exporter/cronjob_greeting.prom 
# HELP node_cronjob_status Last exit code of cronjob.
# TYPE node_cronjob_status gauge
node_cronjob_status{user="vagrant", description="greeting"} 0
```