### PR TITLE
smartmon: add percent_lifetime_remain as allowed smart_attribute

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -45,6 +45,7 @@ smart_attributes_whitelist = (
     'wear_leveling_count',
     'nand_writes_1gib',
     'offline_uncorrectable',
+    'percent_lifetime_remain',
     'power_cycle_count',
     'power_on_hours',
     'program_fail_count',

--- a/smartmon.sh
+++ b/smartmon.sh
@@ -43,6 +43,7 @@ load_cycle_count
 media_wearout_indicator
 nand_writes_1gib
 offline_uncorrectable
+percent_lifetime_remain
 power_cycle_count
 power_on_hours
 program_fail_cnt_total


### PR DESCRIPTION
Added S.M.A.R.T attribute `percent_lifetime_remain` to smartmon scripts for SSD vendors like Micron/Crucial.