### PR TITLE
[yum.sh] Explicitly disable "running kernel"-check

### DIFF
--- a/yum.sh
+++ b/yum.sh
@@ -20,7 +20,7 @@ mute && /^[[:print:]]+\.[[:print:]]+/ {
 '
 
 check_upgrades() {
-  /usr/bin/yum -q check-update |
+  /usr/bin/yum -q --setopt=autocheck_running_kernel=0 check-update |
     /usr/bin/xargs -n3 |
     awk "${filter_awk_script}" |
     sort |


### PR DESCRIPTION
On my OracleLinux 8 and 9 machines, I get unexpected output when a kernel update has been installed but the node has not yet rebooted to run the new kernel. The issue is that "autocheck_running_kernel" is enabled on these machines, and it causes yum/dnf to output things the script doesn't expect. The setting may not be enabled on other systems, but it seems like a sane solution to disable it to force a consistent behaviour regardless of the system-wide settings.

The problem shows itself like this:
```txt
# ./yum.sh
# HELP yum_upgrades_pending Yum package pending updates by origin.
# TYPE yum_upgrades_pending gauge
yum_upgrades_pending{origin="is"} 1
yum_upgrades_pending{origin="kernel-core-4.18.0-553.33.1.el8_10.x86_64"} 1
# HELP node_reboot_required Node reboot is required for software updates.
# TYPE node_reboot_required gauge
node_reboot_required 1
```

This is because the output is as follows (forcing the setting on to make reproduction easier):
```txt
# yum -q --setopt=autocheck_running_kernel=1 check-update
Security: kernel-core-4.18.0-553.34.1.el8_10.x86_64 is an installed security update
Security: kernel-core-4.18.0-553.33.1.el8_10.x86_64 is the currently running version
```

With this commit applied, the collector script works as desired:
```txt
# HELP yum_upgrades_pending Yum package pending updates by origin.
# TYPE yum_upgrades_pending gauge
yum_upgrades_pending{origin=""} 0
# HELP node_reboot_required Node reboot is required for software updates.
# TYPE node_reboot_required gauge
node_reboot_required 1
```

Tested on OracleLinux 8 and 9.