### PR TITLE
collect more apt metrics (Closes: #220)

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -55,7 +55,7 @@ def _convert_candidates_to_upgrade_infos(candidates):
 
 def _write_pending_upgrades(registry, cache):
     candidates = {
-        p.candidate for p in cache if p.is_upgradable
+        p.candidate for p in cache if p.is_upgradable and not p.phasing_applied
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
@@ -69,7 +69,11 @@ def _write_pending_upgrades(registry, cache):
 def _write_held_upgrades(registry, cache):
     held_candidates = {
         p.candidate for p in cache
-        if p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
+        if (
+            p.is_upgradable
+            and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
+            and not p.phasing_applied
+        )
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 

--- a/apt_info.py
+++ b/apt_info.py
@@ -126,7 +126,7 @@ def _write_obsolete_packages(registry, cache, exclusions):
                 package.candidate.architecture,
             )
 
-    g = Gauge('apt_packages_obsolete_count', "Apt packages which are obsolete",
+    g = Gauge('apt_packages_obsolete', "Apt packages which are obsolete",
               registry=registry)
     g.set(len(obsoletes))
 
@@ -153,7 +153,7 @@ def _write_installed_packages_per_origin(registry, cache):
     per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
 
     if per_origin:
-        g = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.",
+        g = Gauge('apt_packages_per_origin', "Number of packages installed per origin.",
                   ['origin', 'arch'], registry=registry)
         for o in per_origin:
             g.labels(o.labels['origin'], o.labels['arch']).set(o.count)


### PR DESCRIPTION
This patch series adds some more information about:

* total installed packages, per arch and origin
* obsolete packages -- those without a candidate, an origin or a with only one origin that points to local storage

It also adds filtering for packages that are marked for phasing upgrades. In this situation, the upgrades are not really pending anymore but just delayed until they are actually processed.