### PR TITLE
Always write value for apt_upgrades_pending and apt_upgrades_held

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -60,7 +60,7 @@ def _write_pending_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
     g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
-        ['origin', 'arch'], registry=registry)
+                ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
@@ -76,7 +76,7 @@ def _write_held_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 
     g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
-        ['origin', 'arch'], registry=registry)
+                ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)

--- a/apt_info.py
+++ b/apt_info.py
@@ -61,7 +61,6 @@ def _write_pending_upgrades(registry, cache):
 
     g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
                   ['origin', 'arch'], registry=registry)
-
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
@@ -78,7 +77,6 @@ def _write_held_upgrades(registry, cache):
 
     g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
                   ['origin', 'arch'], registry=registry)
-
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)

--- a/apt_info.py
+++ b/apt_info.py
@@ -60,7 +60,7 @@ def _write_pending_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
     g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
-                ['origin', 'arch'], registry=registry)
+              ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
@@ -76,7 +76,7 @@ def _write_held_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 
     g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
-                ['origin', 'arch'], registry=registry)
+              ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)

--- a/apt_info.py
+++ b/apt_info.py
@@ -60,7 +60,7 @@ def _write_pending_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
     g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
-                  ['origin', 'arch'], registry=registry)
+        ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
@@ -76,7 +76,7 @@ def _write_held_upgrades(registry, cache):
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 
     g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
-                  ['origin', 'arch'], registry=registry)
+        ['origin', 'arch'], registry=registry)
     if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)

--- a/apt_info.py
+++ b/apt_info.py
@@ -59,11 +59,14 @@ def _write_pending_upgrades(registry, cache):
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
 
-    if upgrade_list:
-        g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
+    g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
                   ['origin', 'arch'], registry=registry)
+
+    if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
+    else:
+        g.labels("", "").set(0)
 
 
 def _write_held_upgrades(registry, cache):
@@ -73,11 +76,14 @@ def _write_held_upgrades(registry, cache):
     }
     upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
 
-    if upgrade_list:
-        g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
+    g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
                   ['origin', 'arch'], registry=registry)
+
+    if upgrade_list:
         for change in upgrade_list:
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
+    else:
+        g.labels("", "").set(0)
 
 
 def _write_autoremove_pending(registry, cache):


### PR DESCRIPTION
Always write value for apt_upgrades_pending and apt_upgrades_held to ensure monitoring works.

If there are no held packages or no pending upgrades, nothing is written to apt.prom, resulting in monitoring dashboards not picking up on these values. This patch fixes that by ensuring there's always a value for apt_upgrades_pending and apt_upgrades_held .