### PR TITLE
[directory-size.sh] Support spaces in paths

### DIFF
--- a/directory-size.sh
+++ b/directory-size.sh
@@ -6,8 +6,6 @@
 #
 # */5 * * * * prometheus directory-size.sh /var/lib/prometheus | sponge /var/lib/node_exporter/directory_size.prom
 #
-# awk logic from by https://stackoverflow.com/a/10221507
-#
 # Author: Antoine Beaupré <anarcat@debian.org>
 
 echo "# HELP node_directory_size_bytes Disk space used by some directories"

--- a/directory-size.sh
+++ b/directory-size.sh
@@ -13,4 +13,7 @@
 echo "# HELP node_directory_size_bytes Disk space used by some directories"
 echo "# TYPE node_directory_size_bytes gauge"
 du --block-size=1 --summarize "$@" \
-  | awk '{ sz = $1; $1 = ""; print "node_directory_size_bytes{directory=\"" substr($0, 2) "\"} "  sz }'
+  | sed -E \
+    -e 's/\\/\\\\/g' \
+    -e 's/"/\\"/g' \
+    -e 's/^([0-9]+)[[:blank:]](.+)$/node_directory_size_bytes{directory="\2"} \1/'

--- a/directory-size.sh
+++ b/directory-size.sh
@@ -6,9 +6,11 @@
 #
 # */5 * * * * prometheus directory-size.sh /var/lib/prometheus | sponge /var/lib/node_exporter/directory_size.prom
 #
+# awk logic from by https://stackoverflow.com/a/10221507
+#
 # Author: Antoine Beaupré <anarcat@debian.org>
 
 echo "# HELP node_directory_size_bytes Disk space used by some directories"
 echo "# TYPE node_directory_size_bytes gauge"
 du --block-size=1 --summarize "$@" \
-  | awk '{ print "node_directory_size_bytes{directory=\"" $2 "\"} "  $1 }'
+  | awk '{ sz = $1; $1 = ""; print "node_directory_size_bytes{directory=\"" substr($0, 2) "\"} "  sz }'


### PR DESCRIPTION
The current code emits directory label only up to the first space, due to the default behavior of `awk`. This change pulls in the rest of the line output from `du` into the label, so directories containing spaces are properly captured