### PR TITLE
Add nvme-cli 2.3 compat

### DIFF
--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -164,7 +164,8 @@ def exec_nvme_json(*args, has_verbose):
     # be verbose. Older versions of nvme-cli optionally produced verbose output if the --verbose
     # flag was specified. In order to avoid having to handle two different JSON schemas, always
     # add the --verbose flag.
-    # Note2: nvme-cli 2.3 that ships with Debian 12 has no verbose parameter for smart-log command only
+    # Note2: nvme-cli 2.3 that ships with Debian 12 has
+    # no verbose parameter for smart-log command only
 
     if "smart-log" in args and not has_verbose:
         output = exec_nvme(*args, "--output-format", "json")

--- a/nvme_metrics.py
+++ b/nvme_metrics.py
@@ -167,10 +167,18 @@ def exec_nvme_json(*args, has_verbose):
     # Note2: nvme-cli 2.3 that ships with Debian 12 has
     # no verbose parameter for smart-log command only
 
-    if "smart-log" in args and not has_verbose:
-        output = exec_nvme(*args, "--output-format", "json")
-    else:
-        output = exec_nvme(*args, "--output-format", "json", "--verbose")
+    try:
+        if "smart-log" in args and not has_verbose:
+            output = exec_nvme(*args, "--output-format", "json")
+        else:
+            output = exec_nvme(*args, "--output-format", "json", "--verbose")
+    except subprocess.CalledProcessError as exc:
+        try:
+            output = json.loads(exc.output)
+            if "Failed to scan topology" in output["error"]:
+                return {"Devices": []}
+        except json.JSONDecodeError:
+            raise ValueError("Cannot parse nvme binary output")
     return json.loads(output)
 
 


### PR DESCRIPTION
Debian 12 (proxmox) ships with nvme-cli 2.3 which has no `--verbose` parameter for `smart-log` command.
We check if `--verbose` exists, and deactivate it if not present.

Patch has been tested on Debian 12 and RHEL 9 (with nvme-cli 2.11) in order to ensure there is no regression.