### PR TITLE
Don't exit on unknown device types

### DIFF
--- a/smartmon.sh
+++ b/smartmon.sh
@@ -200,7 +200,7 @@ for device in ${device_list}; do
   usbprolific) smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
   *)
       (>&2 echo "disk type is not sat, scsi, nvme or megaraid but ${type}")
-    exit
+    continue
     ;;
   esac
 done | format_output


### PR DESCRIPTION
I get `disk type is not sat, scsi, nvme or megaraid but sntrealtek`, which aborts the whole run for no reason.

Looks like a 13 year old bug :)