### PR TITLE
fix apt cache timestamp logic

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -94,13 +94,20 @@ def _write_autoremove_pending(registry, cache):
 def _write_cache_timestamps(registry):
     g = Gauge('apt_package_cache_timestamp_seconds', "Apt update last run time.", registry=registry)
     apt_pkg.init_config()
-    if (
-        apt_pkg.config.find_b("APT::Periodic::Update-Package-Lists") and
-        os.path.isfile("/var/lib/apt/periodic/update-success-stamp")
-    ):
-        # if we run updates automatically with APT::Periodic, we can
-        # check this timestamp file if it exists
+    if os.path.isfile("/var/lib/apt/periodic/update-success-stamp"):
+        # this file is often used as a flag file for sucessful runs on
+        # systems that do not use apt-periodic features, namely
+        # apt-config-auto-update and the Puppetlabs "apt" puppet
+        # module.
+        #
+        # Example configuration:
+        #
+        # APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp";};
         stamp_file = "/var/lib/apt/periodic/update-success-stamp"
+    elif apt_pkg.config.find_b("APT::Periodic::Update-Package-Lists"):
+        # if we run updates automatically with APT::Periodic, we can
+        # check this timestamp file
+        stamp_file = "/var/lib/apt/periodic/update-stamp"
     else:
         # if not, let's just fallback on the partial file of the lists directory
         stamp_file = '/var/lib/apt/lists/partial'


### PR DESCRIPTION
I just stumbled upon a host where there is not `update-success-stamp` at all. Turns out this file is actually site-specific to our environment and is created by a Puppet module we use.

It's not standard: the APT::Periodic feature flags updates with the `update-stamp` file instead!

So let's split the check into multiple, distinct heuristics:

 1. if the `update-success-stamp` file exist, use it and disregard the rest

 2. failing that, if `APT::Periodic` is configured, check `update-stamp`, which does roughly the same (but won't update on a plain `apt update`)

 3. failing that, check `/var/lib/apt/lists/partial` which *works* but might give a false timestamps when apt-get *fails* to get an update, as that directory's timestamp is always updated

Because of (3), we still need the other heuristics.