### PR TITLE
apt_info: massive optimizations and rewrite

### DIFF
--- a/apt_info.py
+++ b/apt_info.py
@@ -65,7 +65,9 @@ def _write_pending_upgrades(registry, cache, exclusions):
     candidates = {
         p.candidate
         for p in cache
-        if p.is_upgradable and not p.phasing_applied and p.name not in exclusions
+        if p.is_upgradable and p.name not in exclusions
+        # Package.phasing_applied is not available in debian bookworm
+        # if p.is_upgradable and not p.phasing_applied and p.name not in exclusions
     }
     for candidate in candidates:
         logging.debug(
@@ -90,8 +92,9 @@ def _write_held_upgrades(registry, cache, exclusions):
         if (
             p.is_upgradable
             and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
-            and not p.phasing_applied
             and p.name not in exclusions
+            # Package.phasing_applied is not available in debian bookworm
+            # and not p.phasing_applied
         )
     }
     for candidate in held_candidates:

--- a/apt_info.py
+++ b/apt_info.py
@@ -42,11 +42,15 @@ def _convert_candidates_to_upgrade_infos(candidates):
         # to filter the candidates on those kinds of conditions before reaching
         # here so here we don't want to include this information in order to
         # reduce noise in the data.
-        origins = sorted(
-            {f"{o.origin}:{o.codename}/{o.archive}" for o in candidate.origins
-             if o.archive != 'now'}
-        )
-        changes_dict[",".join(origins)][candidate.architecture] += 1
+        origins = set()
+        # this is like candidate.origins, but without the expensive
+        # find_index() that we do not need
+        for f, _ in candidate._cand.file_list:
+            if f.archive == "now":
+                continue
+            origins.add(f"{f.origin}:{f.codename}/{f.archive}")
+
+        changes_dict[",".join(sorted(origins))][candidate.architecture] += 1
 
     changes_list = list()
     for origin in sorted(changes_dict.keys()):
@@ -69,14 +73,20 @@ def is_obsolete(p):
     # no candidate, obsolete
     if p.candidate is None:
         return True
-    # cache the expensive origins lookup
-    origins = p.candidate.origins
+    # replace the expensive candidate.origins lookup
+    #
+    # we do this because the Origin constructor performs an expensive
+    # find_index() call every time, which we do not need
+    origins = p.candidate._cand.file_list
     # there is a candidate, but we don't have that version
     # installed for some reason, obsolete
-    if (
-        not origins
-        or (len(origins) == 1 and origins[0].origin in ["", "/var/lib/dpkg/status"])
-    ):
+    if not origins:
+        return True
+    # origins[0] is the first origin of the file_list and
+    # origins[0][0] is a lookup through the `file_list`, which returns
+    # a (PackageFile, offset) tuple, and the PackageFile is what we're
+    # interested in.
+    if len(origins) == 1 and origins[0][0].origin in ["", "/var/lib/dpkg/status"]:
         return True
 
 
@@ -145,7 +155,7 @@ def _write_packages_states(registry, cache, exclusions):
         if package.is_auto_removable:
             autoremovable_packages.add(package.candidate)
 
-        if is_obsolete(package):
+        if package.is_installed and is_obsolete(package):
             obsoletes.append(package)
 
         # Package.phasing_applied is not available in debian bookworm

--- a/apt_info.py
+++ b/apt_info.py
@@ -172,15 +172,24 @@ def _write_packages_states(registry, cache, exclusions):
         apt_pkg.CURSTATE_NOT_INSTALLED: "not-installed",
         apt_pkg.CURSTATE_UNPACKED: "unpacked",
     }
+    # counter for the various values
+    #
+    # we don't use the inc() function here because it's too slow for
+    # the hot loop
+    states_counts = {}
     for key, value in states_to_text.items():
         g.labels(value).set(0)
+        states_counts[key] = 0
 
     for package in cache:
         label_name = states_to_text.get(package._pkg.current_state, None)
         if label_name is None:
             logging.warning("unknown package state for package %s: %s", package, package._pkg.current_state)
             continue
-        g.labels(label_name).inc()
+        states_counts[package._pkg.current_state]+=1
+
+    for key, label_name in states_to_text.items():
+        g.labels(label_name).set(states_counts[key])
 
 
 def _write_autoremove_pending(registry, cache, exclusions):

--- a/apt_info.py
+++ b/apt_info.py
@@ -116,13 +116,28 @@ def _write_held_upgrades(registry, cache, exclusions):
 
 def _write_obsolete_packages(registry, cache, exclusions):
     # This corresponds to the apt filter "?obsolete"
-    obsoletes = [p for p in cache if p.is_installed and (
-                  p.candidate is None or
-                  not p.candidate.origins or
-                  (len(p.candidate.origins) == 1 and
-                   p.candidate.origins[0].origin in ['', "/var/lib/dpkg/status"])
-                  and p.name not in exclusions
-                )]
+    obsoletes = []
+    for p in cache:
+        if p.name in exclusions:
+            continue
+        # not installed, so not obsolete
+        if not p.is_installed:
+            continue
+        # no candidate, obsolete
+        if p.candidate is None:
+            obsoletes.append(p)
+            continue
+        # cache the expensive origins lookup
+        origins = p.candidate.origins
+        # there is a candidate, but we don't have that version
+        # installed for some reason, obsolete
+        if (
+            not origins
+            or (len(origins) == 1 and origins[0].origin in ["", "/var/lib/dpkg/status"])
+        ):
+            obsoletes.append(p)
+            continue
+
     for package in obsoletes:
         if package.candidate is None:
             logging.debug("obsolete package with no candidate: %s", package)

--- a/apt_info.py
+++ b/apt_info.py
@@ -86,15 +86,19 @@ def _write_pending_upgrades(registry, cache, exclusions):
         g.labels("", "").set(0)
 
 
+def is_held(p):
+    # Package.phasing_applied is not available in debian bookworm
+    # would be: and not p.phasing_applied
+    return p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
+
+
+
 def _write_held_upgrades(registry, cache, exclusions):
     held_candidates = {
         p.candidate for p in cache
         if (
-            p.is_upgradable
-            and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
-            and p.name not in exclusions
-            # Package.phasing_applied is not available in debian bookworm
-            # and not p.phasing_applied
+            p.name not in exclusions and
+            is_held(p)
         )
     }
     for candidate in held_candidates:
@@ -114,29 +118,32 @@ def _write_held_upgrades(registry, cache, exclusions):
         g.labels("", "").set(0)
 
 
+def is_obsolete(p):
+    # not installed, so not obsolete
+    if not p.is_installed:
+        return
+    # no candidate, obsolete
+    if p.candidate is None:
+        return True
+    # cache the expensive origins lookup
+    origins = p.candidate.origins
+    # there is a candidate, but we don't have that version
+    # installed for some reason, obsolete
+    if (
+        not origins
+        or (len(origins) == 1 and origins[0].origin in ["", "/var/lib/dpkg/status"])
+    ):
+        return True
+
+
 def _write_obsolete_packages(registry, cache, exclusions):
     # This corresponds to the apt filter "?obsolete"
     obsoletes = []
     for p in cache:
         if p.name in exclusions:
-            continue
-        # not installed, so not obsolete
-        if not p.is_installed:
-            continue
-        # no candidate, obsolete
-        if p.candidate is None:
+            return
+        if is_obsolete(p):
             obsoletes.append(p)
-            continue
-        # cache the expensive origins lookup
-        origins = p.candidate.origins
-        # there is a candidate, but we don't have that version
-        # installed for some reason, obsolete
-        if (
-            not origins
-            or (len(origins) == 1 and origins[0].origin in ["", "/var/lib/dpkg/status"])
-        ):
-            obsoletes.append(p)
-            continue
 
     for package in obsoletes:
         if package.candidate is None:

--- a/apt_info.py
+++ b/apt_info.py
@@ -137,9 +137,13 @@ def _write_packages_states(registry, cache, exclusions):
     for package in cache:
         label_name = states_to_text.get(package._pkg.current_state, None)
         if label_name is None:
-            logging.warning("unknown package state for package %s: %s", package, package._pkg.current_state)
+            logging.warning(
+                "unknown package state for package %s: %s",
+                package,
+                package._pkg.current_state,
+            )
         else:
-            states_counts[package._pkg.current_state]+=1
+            states_counts[package._pkg.current_state] += 1
 
         if package.is_installed:
             installed_packages.add(package.candidate)
@@ -165,7 +169,12 @@ def _write_packages_states(registry, cache, exclusions):
             obsoletes.append(package)
 
     # installed packages per origin
-    packages_per_origin_count = Gauge('apt_packages_per_origin', "Number of packages installed per origin.", ['origin', 'arch'], registry=registry)
+    packages_per_origin_count = Gauge(
+        'apt_packages_per_origin',
+        "Number of packages installed per origin.",
+        ['origin', 'arch'],
+        registry=registry,
+    )
     per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
 
     for o in per_origin:

--- a/apt_info.py
+++ b/apt_info.py
@@ -138,6 +138,51 @@ def _write_obsolete_packages(registry, cache, exclusions):
     g.set(len(obsoletes))
 
 
+def _write_packages_states(registry, cache, exclusions):
+    g = Gauge('apt_packages_count', "Apt packages count.", ['state'], registry=registry)
+
+    # apt_pkg.CURSTATE_CONFIG_FILES
+    #
+    #     Only the configuration files of the package exist on the system.
+    #
+    # apt_pkg.CURSTATE_HALF_CONFIGURED
+    #
+    #     The package is unpacked and configuration has been started, but not yet completed.
+    #
+    # apt_pkg.CURSTATE_HALF_INSTALLED
+    #
+    #     The installation of the package has been started, but not completed.
+    #
+    # apt_pkg.CURSTATE_INSTALLED
+    #
+    #     The package is unpacked, configured and OK.
+    #
+    # apt_pkg.CURSTATE_NOT_INSTALLED
+    #
+    #     The package is not installed.
+    #
+    # apt_pkg.CURSTATE_UNPACKED
+    #
+    #     The package is unpacked, but not configured.
+    states_to_text = {
+        apt_pkg.CURSTATE_CONFIG_FILES: "config-files",
+        apt_pkg.CURSTATE_HALF_CONFIGURED: "half-configured",
+        apt_pkg.CURSTATE_HALF_INSTALLED: "half-installed",
+        apt_pkg.CURSTATE_INSTALLED: "installed",
+        apt_pkg.CURSTATE_NOT_INSTALLED: "not-installed",
+        apt_pkg.CURSTATE_UNPACKED: "unpacked",
+    }
+    for key, value in states_to_text.items():
+        g.labels(value).set(0)
+
+    for package in cache:
+        label_name = states_to_text.get(package._pkg.current_state, None)
+        if label_name is None:
+            logging.warning("unknown package state for package %s: %s", package, package._pkg.current_state)
+            continue
+        g.labels(label_name).inc()
+
+
 def _write_autoremove_pending(registry, cache, exclusions):
     autoremovable_packages = {
         p.candidate
@@ -209,6 +254,7 @@ def _main():
     cache = apt.cache.Cache()
 
     registry = CollectorRegistry()
+    _write_packages_states(registry, cache, args.exclude)
     _write_pending_upgrades(registry, cache, args.exclude)
     _write_held_upgrades(registry, cache, args.exclude)
     _write_obsolete_packages(registry, cache, args.exclude)

--- a/apt_info.py
+++ b/apt_info.py
@@ -130,7 +130,7 @@ def _write_obsolete_packages(registry, cache, exclusions):
                 package.candidate.architecture,
             )
 
-    g = Gauge('apt_packages_obsolete', "Apt packages which are obsolete",
+    g = Gauge('apt_packages_obsolete_count', "Apt packages which are obsolete",
               registry=registry)
     g.set(len(obsoletes))
 
@@ -157,7 +157,7 @@ def _write_installed_packages_per_origin(registry, cache):
     per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
 
     if per_origin:
-        g = Gauge('apt_packages_per_origin', "Number of packages installed per origin.",
+        g = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.",
                   ['origin', 'arch'], registry=registry)
         for o in per_origin:
             g.labels(o.labels['origin'], o.labels['arch']).set(o.count)

--- a/apt_info.py
+++ b/apt_info.py
@@ -67,9 +67,6 @@ def _convert_candidates_to_upgrade_infos(candidates):
 
 # This corresponds to the apt filter "?obsolete"
 def is_obsolete(p):
-    # not installed, so not obsolete
-    if not p.is_installed:
-        return
     # no candidate, obsolete
     if p.candidate is None:
         return True

--- a/apt_info.py
+++ b/apt_info.py
@@ -165,7 +165,7 @@ def _write_packages_states(registry, cache, exclusions):
             obsoletes.append(package)
 
     # installed packages per origin
-    packages_per_origin_count = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.", ['origin', 'arch'], registry=registry)
+    packages_per_origin_count = Gauge('apt_packages_per_origin', "Number of packages installed per origin.", ['origin', 'arch'], registry=registry)
     per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
 
     for o in per_origin:
@@ -209,7 +209,7 @@ def _write_packages_states(registry, cache, exclusions):
                 package.candidate.architecture,
             )
 
-    g = Gauge('apt_packages_obsolete_count', "Apt packages which are obsolete",
+    g = Gauge('apt_packages_obsolete', "Apt packages which are obsolete",
               registry=registry)
     g.set(len(obsoletes))
 
@@ -229,7 +229,7 @@ def _write_packages_states(registry, cache, exclusions):
             g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
 
     # other package states
-    packages_count = Gauge('apt_packages_count', "Apt packages count.", ['state'], registry=registry)
+    packages_count = Gauge('apt_packages', "Apt packages count.", ['state'], registry=registry)
     for key, label_name in states_to_text.items():
         packages_count.labels(label_name).set(states_counts[key])
 

--- a/apt_info.py
+++ b/apt_info.py
@@ -61,63 +61,7 @@ def _convert_candidates_to_upgrade_infos(candidates):
     return changes_list
 
 
-def _write_pending_upgrades(registry, cache, exclusions):
-    candidates = {
-        p.candidate
-        for p in cache
-        if p.is_upgradable and p.name not in exclusions
-        # Package.phasing_applied is not available in debian bookworm
-        # if p.is_upgradable and not p.phasing_applied and p.name not in exclusions
-    }
-    for candidate in candidates:
-        logging.debug(
-            "pending upgrade: %s / %s",
-            candidate.package,
-            candidate.architecture,
-        )
-    upgrade_list = _convert_candidates_to_upgrade_infos(candidates)
-
-    g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
-              ['origin', 'arch'], registry=registry)
-    if upgrade_list:
-        for change in upgrade_list:
-            g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
-    else:
-        g.labels("", "").set(0)
-
-
-def is_held(p):
-    # Package.phasing_applied is not available in debian bookworm
-    # would be: and not p.phasing_applied
-    return p.is_upgradable and p._pkg.selected_state == apt_pkg.SELSTATE_HOLD
-
-
-
-def _write_held_upgrades(registry, cache, exclusions):
-    held_candidates = {
-        p.candidate for p in cache
-        if (
-            p.name not in exclusions and
-            is_held(p)
-        )
-    }
-    for candidate in held_candidates:
-        logging.debug(
-            "held upgrade: %s / %s",
-            candidate.package,
-            candidate.architecture,
-        )
-    upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
-
-    g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
-              ['origin', 'arch'], registry=registry)
-    if upgrade_list:
-        for change in upgrade_list:
-            g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
-    else:
-        g.labels("", "").set(0)
-
-
+# This corresponds to the apt filter "?obsolete"
 def is_obsolete(p):
     # not installed, so not obsolete
     if not p.is_installed:
@@ -136,32 +80,12 @@ def is_obsolete(p):
         return True
 
 
-def _write_obsolete_packages(registry, cache, exclusions):
-    # This corresponds to the apt filter "?obsolete"
-    obsoletes = []
-    for p in cache:
-        if p.name in exclusions:
-            return
-        if is_obsolete(p):
-            obsoletes.append(p)
-
-    for package in obsoletes:
-        if package.candidate is None:
-            logging.debug("obsolete package with no candidate: %s", package)
-        else:
-            logging.debug(
-                "obsolete package: %s / %s",
-                package,
-                package.candidate.architecture,
-            )
-
-    g = Gauge('apt_packages_obsolete_count', "Apt packages which are obsolete",
-              registry=registry)
-    g.set(len(obsoletes))
-
-
 def _write_packages_states(registry, cache, exclusions):
-    g = Gauge('apt_packages_count', "Apt packages count.", ['state'], registry=registry)
+    installed_packages = set()
+    upgrade_candidates = set()
+    autoremovable_packages = set()
+    obsoletes = []
+    held_candidates = set()
 
     # apt_pkg.CURSTATE_CONFIG_FILES
     #
@@ -200,46 +124,104 @@ def _write_packages_states(registry, cache, exclusions):
     # the hot loop
     states_counts = {}
     for key, value in states_to_text.items():
-        g.labels(value).set(0)
         states_counts[key] = 0
 
     for package in cache:
         label_name = states_to_text.get(package._pkg.current_state, None)
         if label_name is None:
             logging.warning("unknown package state for package %s: %s", package, package._pkg.current_state)
+        else:
+            states_counts[package._pkg.current_state]+=1
+
+        if package.is_installed:
+            installed_packages.add(package.candidate)
+
+        if package.name in exclusions:
             continue
-        states_counts[package._pkg.current_state]+=1
 
-    for key, label_name in states_to_text.items():
-        g.labels(label_name).set(states_counts[key])
+        if package.is_upgradable:
+            upgrade_candidates.add(package.candidate)
 
+        if package.is_auto_removable:
+            autoremovable_packages.add(package.candidate)
 
-def _write_autoremove_pending(registry, cache, exclusions):
-    autoremovable_packages = {
-        p.candidate
-        for p in cache
-        if p.is_auto_removable and p.name not in exclusions
-    }
+        if is_obsolete(package):
+            obsoletes.append(package)
+
+        # Package.phasing_applied is not available in debian bookworm
+        # would be: and not p.phasing_applied
+        if package.is_upgradable and package._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
+            held_candidates.add(package.candidate)
+
+    # installed packages per origin
+    packages_per_origin_count = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.", ['origin', 'arch'], registry=registry)
+    per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
+
+    if per_origin:
+        for o in per_origin:
+            packages_per_origin_count.labels(o.labels['origin'], o.labels['arch']).set(o.count)
+
+    # upgradable packages
+    for candidate in upgrade_candidates:
+        logging.debug(
+            "pending upgrade: %s / %s",
+            candidate.package,
+            candidate.architecture,
+        )
+    upgrade_list = _convert_candidates_to_upgrade_infos(upgrade_candidates)
+
+    if upgrade_list:
+        g = Gauge('apt_upgrades_pending', "Apt packages pending updates by origin",
+                  ['origin', 'arch'], registry=registry)
+        for change in upgrade_list:
+            g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
+
+    # autoremove packages
     for candidate in autoremovable_packages:
         logging.debug(
             "autoremovable package: %s / %s",
             candidate.package,
             candidate.architecture,
         )
+
     g = Gauge('apt_autoremove_pending', "Apt packages pending autoremoval.",
               registry=registry)
     g.set(len(autoremovable_packages))
 
+    # obsolete packages
+    for package in obsoletes:
+        if package.candidate is None:
+            logging.debug("obsolete package with no candidate: %s", package)
+        else:
+            logging.debug(
+                "obsolete package: %s / %s",
+                package,
+                package.candidate.architecture,
+            )
 
-def _write_installed_packages_per_origin(registry, cache):
-    installed_packages = {p.candidate for p in cache if p.is_installed}
-    per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
+    g = Gauge('apt_packages_obsolete_count', "Apt packages which are obsolete",
+              registry=registry)
+    g.set(len(obsoletes))
 
-    if per_origin:
-        g = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.",
+    # held packages
+    for candidate in held_candidates:
+        logging.debug(
+            "held upgrade: %s / %s",
+            candidate.package,
+            candidate.architecture,
+        )
+    upgrade_list = _convert_candidates_to_upgrade_infos(held_candidates)
+
+    if upgrade_list:
+        g = Gauge('apt_upgrades_held', "Apt packages pending updates but held back.",
                   ['origin', 'arch'], registry=registry)
-        for o in per_origin:
-            g.labels(o.labels['origin'], o.labels['arch']).set(o.count)
+        for change in upgrade_list:
+            g.labels(change.labels['origin'], change.labels['arch']).set(change.count)
+
+    # other package states
+    packages_count = Gauge('apt_packages_count', "Apt packages count.", ['state'], registry=registry)
+    for key, label_name in states_to_text.items():
+        packages_count.labels(label_name).set(states_counts[key])
 
 
 def _write_cache_timestamps(registry):
@@ -286,11 +268,6 @@ def _main():
 
     registry = CollectorRegistry()
     _write_packages_states(registry, cache, args.exclude)
-    _write_pending_upgrades(registry, cache, args.exclude)
-    _write_held_upgrades(registry, cache, args.exclude)
-    _write_obsolete_packages(registry, cache, args.exclude)
-    _write_autoremove_pending(registry, cache, args.exclude)
-    _write_installed_packages_per_origin(registry, cache)
     _write_cache_timestamps(registry)
     _write_reboot_required(registry)
     print(generate_latest(registry).decode(), end='')

--- a/apt_info.py
+++ b/apt_info.py
@@ -85,6 +85,7 @@ def is_obsolete(p):
     # interested in.
     if len(origins) == 1 and origins[0][0].origin in ["", "/var/lib/dpkg/status"]:
         return True
+    return False
 
 
 def _write_packages_states(registry, cache, exclusions):
@@ -130,7 +131,7 @@ def _write_packages_states(registry, cache, exclusions):
     # we don't use the inc() function here because it's too slow for
     # the hot loop
     states_counts = {}
-    for key, value in states_to_text.items():
+    for key in states_to_text.keys():
         states_counts[key] = 0
 
     for package in cache:
@@ -143,11 +144,19 @@ def _write_packages_states(registry, cache, exclusions):
         if package.is_installed:
             installed_packages.add(package.candidate)
 
+        # exclusions only apply to upgradable, autoremove, held and obsolete packages
+        #
+        # we still want to count the number of installed packages, and
+        # especially the broken ones
         if package.name in exclusions:
             continue
 
         if package.is_upgradable:
             upgrade_candidates.add(package.candidate)
+            if package._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
+                # Package.phasing_applied is not available in debian bookworm
+                # would be: and not p.phasing_applied
+                held_candidates.add(package.candidate)
 
         if package.is_auto_removable:
             autoremovable_packages.add(package.candidate)
@@ -155,18 +164,12 @@ def _write_packages_states(registry, cache, exclusions):
         if package.is_installed and is_obsolete(package):
             obsoletes.append(package)
 
-        # Package.phasing_applied is not available in debian bookworm
-        # would be: and not p.phasing_applied
-        if package.is_upgradable and package._pkg.selected_state == apt_pkg.SELSTATE_HOLD:
-            held_candidates.add(package.candidate)
-
     # installed packages per origin
     packages_per_origin_count = Gauge('apt_packages_per_origin_count', "Number of packages installed per origin.", ['origin', 'arch'], registry=registry)
     per_origin = _convert_candidates_to_upgrade_infos(installed_packages)
 
-    if per_origin:
-        for o in per_origin:
-            packages_per_origin_count.labels(o.labels['origin'], o.labels['arch']).set(o.count)
+    for o in per_origin:
+        packages_per_origin_count.labels(o.labels['origin'], o.labels['arch']).set(o.count)
 
     # upgradable packages
     for candidate in upgrade_candidates:


### PR DESCRIPTION
This is a set of tweaks to the `apt_info.py` script to optimize collection and reorganize the codebase. It started with an attempt at optimizing the code and ultimately meant essentially rewriting the whole thing since it required refactoring the functions into a single one to optimize data structures.

The performance improvement on my laptop is kind of dramatic:

```
> hyperfine 'python apt_info-34f9073d8.py' 'python apt_info-69fe18add.py' 'python apt_info.py'
Benchmark 1: python apt_info-34f9073d8.py
  Time (mean ± σ):     10.081 s ±  0.318 s    [User: 5.796 s, System: 4.283 s]
  Range (min … max):    9.575 s … 10.832 s    10 runs
 
Benchmark 2: python apt_info-69fe18add.py
  Time (mean ± σ):      9.517 s ±  0.280 s    [User: 5.380 s, System: 4.136 s]
  Range (min … max):    9.101 s …  9.864 s    10 runs
 
Benchmark 3: python apt_info.py
  Time (mean ± σ):     780.7 ms ±  37.3 ms    [User: 741.2 ms, System: 39.3 ms]
  Range (min … max):   732.1 ms … 843.9 ms    10 runs
 
Summary
  python apt_info.py ran
   12.19 ± 0.68 times faster than python apt_info-69fe18add.py
   12.91 ± 0.74 times faster than python apt_info-34f9073d8.py
```

That's 10 seconds to 800ms!!

On a canary server of ours -- a minimal example --  the performance is less impressive, going from 1.6s to 500ms... But still a 3x improvement!

(Note that the filename above include commit hashes that do not exist here, but are from our own monorepo which includes this file, that we're trying to get back in sync with upstream.)

----

This a large number of commits that have accumulated on our end in the past 18 months. We have held from contributing those back because !234 got stuck, but seeing that it's now merged gives us hope that we can contribute again.

I'm really sorry about the state of this PR. I wish things were more orderly, but this is the best I could do with a couple of hours of work.

You'll note that the commit starts with a revert of dc297f1c7ef30c404b24bd798484876b1b4b9067, which changed the metric names, because our patches were made *without* merging that change from !234 that I had completely overlooked. Reverting the patch, applying our patchset, and reapplying the fix was much easier than constantly resolving the conflicts over the rebase. If that's really a problem for the history, I could try rebasing the entire thing without commits, but given the massive rewrite, it's going to be a huge ordeal and I'm not sure I would go through it. I'll also note that 

We still have a small delta after this. I've ran `black` over the file locally, and would love to do so here, but for the sake of readability, I have actually managed to port the patches without `black`. I'd love to hear if such a noop PR would be accepted as well, following this one, to remove our last delta.

Thanks!