### PR TITLE
Add name mapping table for smart attrs

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -79,6 +79,11 @@ smart_attributes_whitelist = (
     'workload_minutes',
 )
 
+# Name map table for attributes that have different names depending on SSD vendor
+smart_attributes_map = {
+    "ssd_life_left": "percent_lifetime_remain"
+}
+
 registry = CollectorRegistry()
 namespace = "smartmon"
 
@@ -366,7 +371,7 @@ def collect_ata_metrics(device):
         # We're only interested in the SMART attributes that are
         # whitelisted here.
         entry['name'] = entry['name'].lower()
-        if entry['name'] not in smart_attributes_whitelist:
+        if entry["name"] not in smart_attributes_whitelist and entry["name"] not in list(smart_attributes_map.keys()):
             continue
 
         # Ensure that only the numeric parts are fetched from the raw_value.
@@ -384,7 +389,9 @@ def collect_ata_metrics(device):
         if entry['threshold'] == '---':
             entry['threshold'] = '0'
 
-        if entry['name'] in smart_attributes_whitelist and entry['name'] not in seen:
+        if (entry["name"] in smart_attributes_whitelist or entry["name"] in list(smart_attributes_map.keys())) and entry["name"] not in seen:
+            if entry["name"] in smart_attributes_map:
+                entry["name"] = smart_attributes_map[entry["name"]]
             for col in 'value', 'worst', 'threshold', 'raw_value':
                 metrics["attr_" + col].labels(
                     device.base_labels["device"],

--- a/smartmon.py
+++ b/smartmon.py
@@ -372,7 +372,7 @@ def collect_ata_metrics(device):
         # whitelisted here.
         entry['name'] = entry['name'].lower()
         if entry["name"] not in smart_attributes_whitelist and \
-            entry["name"] not in list(smart_attributes_map.keys()):
+                entry["name"] not in list(smart_attributes_map.keys()):
             continue
 
         # Ensure that only the numeric parts are fetched from the raw_value.
@@ -390,8 +390,8 @@ def collect_ata_metrics(device):
         if entry['threshold'] == '---':
             entry['threshold'] = '0'
 
-        if (entry["name"] in smart_attributes_whitelist or entry["name"] in \
-            list(smart_attributes_map.keys())) and entry["name"] not in seen:
+        if (entry["name"] in smart_attributes_whitelist or entry["name"] in
+                list(smart_attributes_map.keys())) and entry["name"] not in seen:
             if entry["name"] in smart_attributes_map:
                 entry["name"] = smart_attributes_map[entry["name"]]
             for col in 'value', 'worst', 'threshold', 'raw_value':

--- a/smartmon.py
+++ b/smartmon.py
@@ -371,7 +371,8 @@ def collect_ata_metrics(device):
         # We're only interested in the SMART attributes that are
         # whitelisted here.
         entry['name'] = entry['name'].lower()
-        if entry["name"] not in smart_attributes_whitelist and entry["name"] not in list(smart_attributes_map.keys()):
+        if entry["name"] not in smart_attributes_whitelist and \
+            entry["name"] not in list(smart_attributes_map.keys()):
             continue
 
         # Ensure that only the numeric parts are fetched from the raw_value.
@@ -389,7 +390,8 @@ def collect_ata_metrics(device):
         if entry['threshold'] == '---':
             entry['threshold'] = '0'
 
-        if (entry["name"] in smart_attributes_whitelist or entry["name"] in list(smart_attributes_map.keys())) and entry["name"] not in seen:
+        if (entry["name"] in smart_attributes_whitelist or entry["name"] in \
+            list(smart_attributes_map.keys())) and entry["name"] not in seen:
             if entry["name"] in smart_attributes_map:
                 entry["name"] = smart_attributes_map[entry["name"]]
             for col in 'value', 'worst', 'threshold', 'raw_value':


### PR DESCRIPTION
Some SSD vendors decided that `percent_lifetime_remain` would be called `ssd_life_left`. Let's use a map table in order to fetch those infos in "standard" format